### PR TITLE
chore: use --production flag for npm install

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 
 COPY --from=builder /usr/src/app/dist ./dist
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --omit=dev
 
 COPY entrypoint.sh ./
 RUN ["chmod", "+x", "./entrypoint.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 
 COPY --from=builder /usr/src/app/dist ./dist
 COPY package*.json ./
-RUN npm install
+RUN npm install --production
 
 COPY entrypoint.sh ./
 RUN ["chmod", "+x", "./entrypoint.sh"]


### PR DESCRIPTION
Docker build of `OPinit-bots` uses bare `npm install`, which installs unnecessary dev dependencies as well. Using `--production` flag reduces the size of `node_modules`.

Before: `399M`
After: `216M` 