### PR TITLE
Feat/start height

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To ensure compatibility with the node version, check the following versions:
 
 | L1 Node | MiniMove | MiniWasm | MiniEVM | 
 | ------- | -------- | -------- | ------- | 
-| v0.4.1  | v0.4.1   | v0.4.1   | v0.4.1  | 
+| v0.4.2  | v0.4.0   | v0.4.0   | v0.4.0  | 
 
 ### Build and Configure
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ To reset the bot database, use the following command:
 opinitd reset-db [bot-name]
 ```
 
+### Query status
+```bash
+curl localhost:3000/status
+```
+
 ### Query withdrawals 
 ```bash
 curl localhost:3000/withdrawal/{sequence} | jq . > ./withdrawal-info.json

--- a/bot/types/bot.go
+++ b/bot/types/bot.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Bot interface {
+	Initialize(context.Context) error
 	Start(context.Context) error
 	Close()
 }

--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -1,8 +1,0 @@
-package challenger
-
-type Challenger struct {
-}
-
-func NewChallenger() *Challenger {
-	return &Challenger{}
-}

--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -1,0 +1,8 @@
+package challenger
+
+type Challenger struct {
+}
+
+func NewChallenger() *Challenger {
+	return &Challenger{}
+}

--- a/cmd/opinitd/reset.go
+++ b/cmd/opinitd/reset.go
@@ -25,7 +25,7 @@ func resetDBCmd(ctx *cmdContext) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				err = os.Remove(path.Join(ctx.homePath, "batch"))
+				err = os.RemoveAll(path.Join(ctx.homePath, "batch"))
 				if err != nil {
 					return err
 				}

--- a/cmd/opinitd/start.go
+++ b/cmd/opinitd/start.go
@@ -42,17 +42,19 @@ Currently supported bots:
 			}
 
 			cmdCtx, botDone := context.WithCancel(cmd.Context())
+			gracefulShutdown(botDone)
+
 			errGrp, ctx := errgroup.WithContext(cmdCtx)
 			ctx = types.WithErrGrp(ctx, errGrp)
 			interval, err := cmd.Flags().GetDuration(flagPollingInterval)
+			if err != nil {
+				return err
+			}
 			ctx = types.WithPollingInterval(ctx, interval)
-
 			err = bot.Initialize(ctx)
 			if err != nil {
 				return err
 			}
-
-			gracefulShutdown(botDone)
 			return bot.Start(ctx)
 		},
 	}

--- a/executor/README.md
+++ b/executor/README.md
@@ -64,10 +64,6 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   // L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
   // L1 starts from the block number of the output tx + 1
   "l2_start_height": 0,
-  // BatchStartWithL2Height is the flag to start the batch same with the l2 height.
-  // If the latest height stored in the db is not 0, this config is ignored.
-  // If it is true, the batch will start from the last submitted output l2 block number + 1.
-  "batch_start_with_l2_height": false,
   // StartBatchHeight is the height to start the batch. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
   "batch_start_height": 0
@@ -105,7 +101,6 @@ FinalizedTokenDeposit tx 2
 ```json
 {
   l2_start_height: 150, 
-  batch_start_with_l2_height: false, 
   batch_start_height: 0
 }
 ```
@@ -118,7 +113,6 @@ When Child's last l1 Sequence is `2`,
 ```json
 {
   l2_start_height: 150, 
-  batch_start_with_l2_height: false, 
   batch_start_height: 150
 }
 ```
@@ -131,27 +125,13 @@ When Child's last l1 Sequence is `2`,
 ```json
 {
   l2_start_height: 150, 
-  batch_start_with_l2_height: true, 
-  batch_start_height: 150
-}
-```
-When Child's last l1 Sequence is `2`,
-- L1 starts from the height 10 + 1 = 11
-- L2 starts from the height 100 + 1 = 101
-- Batch starts from the height 101
-
-#### Config 4
-```json
-{
-  l2_start_height: 150, 
-  batch_start_with_l2_height: true, 
   batch_start_height: 150
 }
 ```
 When Child's last l1 Sequence is `1`,
 - L1 starts from the height 5 + 1 = 6
 - L2 starts from the height 100 + 1 = 101
-- Batch starts from the height 101
+- Batch starts from the height 150
 
 
 ## Handler rules for the components of the Executor

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -23,7 +23,7 @@ import (
 )
 
 type hostNode interface {
-	QueryBatchInfos() (*ophosttypes.QueryBatchInfosResponse, error)
+	QueryBatchInfos(uint64) (*ophosttypes.QueryBatchInfosResponse, error)
 }
 
 type compressionFunc interface {
@@ -112,7 +112,7 @@ func (bs *BatchSubmitter) Initialize(startHeight uint64, host hostNode, bridgeIn
 	bs.host = host
 	bs.bridgeInfo = bridgeInfo
 
-	res, err := bs.host.QueryBatchInfos()
+	res, err := bs.host.QueryBatchInfos(bridgeInfo.BridgeId)
 	if err != nil {
 		return err
 	}

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -129,7 +129,7 @@ func (bs *BatchSubmitter) Initialize(startHeight uint64, host hostNode, bridgeIn
 
 	fileFlag := os.O_CREATE | os.O_RDWR
 	// if the node has already processed blocks, append to the file
-	if bs.node.GetHeight()-1 != startHeight {
+	if !bs.node.HeightInitialized() {
 		fileFlag |= os.O_APPEND
 	}
 

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -62,6 +62,9 @@ type BatchSubmitter struct {
 	homePath string
 
 	lastSubmissionTime time.Time
+
+	// status info
+	LastBatchEndBlockNumber uint64
 }
 
 func NewBatchSubmitter(

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -23,7 +23,7 @@ import (
 )
 
 type hostNode interface {
-	QueryBatchInfos(uint64) (*ophosttypes.QueryBatchInfosResponse, error)
+	QueryBatchInfos(context.Context, uint64) (*ophosttypes.QueryBatchInfosResponse, error)
 }
 
 type compressionFunc interface {
@@ -104,7 +104,7 @@ func NewBatchSubmitter(
 	return ch
 }
 
-func (bs *BatchSubmitter) Initialize(startHeight uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (bs *BatchSubmitter) Initialize(ctx context.Context, startHeight uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
 	err := bs.node.Initialize(startHeight)
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func (bs *BatchSubmitter) Initialize(startHeight uint64, host hostNode, bridgeIn
 	bs.host = host
 	bs.bridgeInfo = bridgeInfo
 
-	res, err := bs.host.QueryBatchInfos(bridgeInfo.BridgeId)
+	res, err := bs.host.QueryBatchInfos(ctx, bridgeInfo.BridgeId)
 	if err != nil {
 		return err
 	}

--- a/executor/batch/handler.go
+++ b/executor/batch/handler.go
@@ -14,8 +14,9 @@ import (
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
 

--- a/executor/batch/handler.go
+++ b/executor/batch/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
@@ -226,6 +227,12 @@ func (bs *BatchSubmitter) finalizeBatch(ctx context.Context, blockHeight uint64)
 		return err
 	}
 
+	bs.logger.Info("finalize batch",
+		zap.Uint64("height", blockHeight),
+		zap.Uint64("batch end", bs.batchHeader.End),
+		zap.Int("chunks", len(checksums)),
+		zap.Int("txs", len(bs.processedMsgs)),
+	)
 	return nil
 }
 
@@ -242,8 +249,6 @@ func (bs *BatchSubmitter) checkBatch(blockHeight uint64, blockTime time.Time) er
 	if blockTime.After(bs.lastSubmissionTime.Add(bs.bridgeInfo.BridgeConfig.SubmissionInterval*2/3)) ||
 		blockTime.After(bs.lastSubmissionTime.Add(time.Duration(bs.batchCfg.MaxSubmissionTime)*time.Second)) ||
 		info.Size() > (bs.batchCfg.MaxChunks-1)*bs.batchCfg.MaxChunkSize {
-
-		// finalize the batch
 
 		// finalize the batch
 		bs.batchHeader.End = blockHeight

--- a/executor/batch/handler.go
+++ b/executor/batch/handler.go
@@ -256,6 +256,11 @@ func (bs *BatchSubmitter) UpdateBatchInfo(chain string, submitter string, output
 	bs.batchInfoMu.Lock()
 	defer bs.batchInfoMu.Unlock()
 
+	// check if the batch info is already updated
+	if bs.batchInfos[len(bs.batchInfos)-1].Output.L2BlockNumber >= l2BlockNumber {
+		return
+	}
+
 	bs.batchInfos = append(bs.batchInfos, ophosttypes.BatchInfoWithOutput{
 		BatchInfo: ophosttypes.BatchInfo{
 			ChainType: ophosttypes.BatchInfo_ChainType(ophosttypes.BatchInfo_ChainType_value["CHAIN_TYPE_"+chain]),

--- a/executor/batch/status.go
+++ b/executor/batch/status.go
@@ -15,14 +15,14 @@ type Status struct {
 	LastBatchSubmissionTime time.Time             `json:"last_batch_submission_time"`
 }
 
-func (b BatchSubmitter) GetStatus() Status {
-	fileSize, _ := b.batchFileSize()
+func (bs BatchSubmitter) GetStatus() Status {
+	fileSize, _ := bs.batchFileSize()
 
 	return Status{
-		Node:                    b.node.GetStatus(),
-		BatchInfo:               b.BatchInfo().BatchInfo,
+		Node:                    bs.node.GetStatus(),
+		BatchInfo:               bs.BatchInfo().BatchInfo,
 		CurrentBatchFileSize:    fileSize,
-		LastBatchEndBlockNumber: b.LastBatchEndBlockNumber,
-		LastBatchSubmissionTime: b.lastSubmissionTime,
+		LastBatchEndBlockNumber: bs.LastBatchEndBlockNumber,
+		LastBatchSubmissionTime: bs.lastSubmissionTime,
 	}
 }

--- a/executor/batch/status.go
+++ b/executor/batch/status.go
@@ -1,0 +1,28 @@
+package batch
+
+import (
+	"time"
+
+	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+)
+
+type Status struct {
+	Node                    nodetypes.Status      `json:"node"`
+	BatchInfo               ophosttypes.BatchInfo `json:"batch_info"`
+	CurrentBatchFileSize    int64                 `json:"current_batch_file_size"`
+	LastBatchEndBlockNumber uint64                `json:"last_batch_end_block_number"`
+	LastBatchSubmissionTime time.Time             `json:"last_batch_submission_time"`
+}
+
+func (b BatchSubmitter) GetStatus() Status {
+	fileSize, _ := b.batchFileSize()
+
+	return Status{
+		Node:                    b.node.GetStatus(),
+		BatchInfo:               b.BatchInfo().BatchInfo,
+		CurrentBatchFileSize:    fileSize,
+		LastBatchEndBlockNumber: b.LastBatchEndBlockNumber,
+		LastBatchSubmissionTime: b.lastSubmissionTime,
+	}
+}

--- a/executor/batch/utils.go
+++ b/executor/batch/utils.go
@@ -4,8 +4,9 @@ import (
 	"encoding/binary"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
 	"github.com/initia-labs/opinit-bots-go/txutils"

--- a/executor/celestia/celestia.go
+++ b/executor/celestia/celestia.go
@@ -93,9 +93,13 @@ func createCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 }
 
 func (c *Celestia) Initialize(batch batchNode, bridgeId int64) error {
+	err := c.node.Initialize(0)
+	if err != nil {
+		return err
+	}
+
 	c.batch = batch
 	c.bridgeId = bridgeId
-	var err error
 	c.namespace, err = sh.NewV0Namespace(c.NamespaceID())
 	if err != nil {
 		return err

--- a/executor/celestia/celestia.go
+++ b/executor/celestia/celestia.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cometbft/cometbft/crypto/merkle"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/executor/celestia/handler.go
+++ b/executor/celestia/handler.go
@@ -1,11 +1,13 @@
 package celestia
 
 import (
+	"context"
+
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 	"go.uber.org/zap"
 )
 
-func (c *Celestia) payForBlobsHandler(args nodetypes.EventHandlerArgs) error {
+func (c *Celestia) payForBlobsHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var signer string
 	var blobSizes string
 	var namespaces string

--- a/executor/celestia/status.go
+++ b/executor/celestia/status.go
@@ -1,0 +1,9 @@
+package celestia
+
+import (
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+)
+
+func (c Celestia) GetNodeStatus() nodetypes.Status {
+	return c.node.GetStatus()
+}

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -109,7 +109,11 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (ch *Child) Initialize(host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (ch *Child) Initialize(startHeight uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+	err := ch.node.Initialize(startHeight)
+	if err != nil {
+		return err
+	}
 	ch.host = host
 	ch.bridgeInfo = bridgeInfo
 

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -29,8 +29,8 @@ type hostNode interface {
 	HasKey() bool
 	BroadcastMsgs(btypes.ProcessedMsgs)
 	ProcessedMsgsToRawKV([]btypes.ProcessedMsgs, bool) ([]types.RawKV, error)
-	QueryLastOutput() (*ophosttypes.QueryOutputProposalResponse, error)
-	QueryOutput(uint64) (*ophosttypes.QueryOutputProposalResponse, error)
+	QueryLastOutput(uint64) (*ophosttypes.QueryOutputProposalResponse, error)
+	QueryOutput(uint64, uint64) (*ophosttypes.QueryOutputProposalResponse, error)
 
 	GetMsgProposeOutput(
 		bridgeId uint64,

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -51,6 +51,7 @@ type Child struct {
 
 	nextOutputTime        time.Time
 	finalizingBlockHeight uint64
+	startTreeIndex        uint64
 
 	cfg    nodetypes.NodeConfig
 	db     types.DB
@@ -109,14 +110,14 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (ch *Child) Initialize(startHeight uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (ch *Child) Initialize(startHeight uint64, startOutputIndex uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
 	err := ch.node.Initialize(startHeight)
 	if err != nil {
 		return err
 	}
+	ch.startTreeIndex = startOutputIndex
 	ch.host = host
 	ch.bridgeInfo = bridgeInfo
-
 	ch.registerHandlers()
 	return nil
 }

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -61,6 +61,12 @@ type Child struct {
 
 	processedMsgs []btypes.ProcessedMsgs
 	msgQueue      []sdk.Msg
+
+	// status info
+	lastUpdatedOracleL1Height         uint64
+	lastFinalizedDepositL1BlockHeight uint64
+	lastFinalizedDepositL1Sequence    uint64
+	lastOutputTime                    time.Time
 }
 
 func NewChild(

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -29,8 +29,8 @@ type hostNode interface {
 	HasKey() bool
 	BroadcastMsgs(btypes.ProcessedMsgs)
 	ProcessedMsgsToRawKV([]btypes.ProcessedMsgs, bool) ([]types.RawKV, error)
-	QueryLastOutput(uint64) (*ophosttypes.QueryOutputProposalResponse, error)
-	QueryOutput(uint64, uint64) (*ophosttypes.QueryOutputProposalResponse, error)
+	QueryLastOutput(context.Context, uint64) (*ophosttypes.QueryOutputProposalResponse, error)
+	QueryOutput(context.Context, uint64, uint64) (*ophosttypes.QueryOutputProposalResponse, error)
 
 	GetMsgProposeOutput(
 		bridgeId uint64,

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -53,7 +53,7 @@ type Child struct {
 	nextOutputTime        time.Time
 	finalizingBlockHeight uint64
 
-	initializeTree   sync.Once
+	initializeTree   *sync.Once
 	initializeTreeFn func() error
 
 	cfg    nodetypes.NodeConfig
@@ -97,7 +97,7 @@ func NewChild(
 		node: node,
 		mk:   mk,
 
-		initializeTree: sync.Once{},
+		initializeTree: &sync.Once{},
 
 		cfg:    cfg,
 		db:     db,

--- a/executor/child/deposit.go
+++ b/executor/child/deposit.go
@@ -6,8 +6,9 @@ import (
 	"strconv"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 	"go.uber.org/zap"

--- a/executor/child/deposit.go
+++ b/executor/child/deposit.go
@@ -49,6 +49,8 @@ func (ch *Child) finalizeDepositHandler(_ context.Context, args nodetypes.EventH
 		}
 	}
 	ch.handleFinalizeDeposit(l1BlockHeight, l1Sequence, from, to, amount, baseDenom)
+	ch.lastFinalizedDepositL1BlockHeight = l1BlockHeight
+	ch.lastFinalizedDepositL1Sequence = l1Sequence
 	return nil
 }
 

--- a/executor/child/deposit.go
+++ b/executor/child/deposit.go
@@ -1,6 +1,7 @@
 package child
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -12,7 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (ch *Child) finalizeDepositHandler(args nodetypes.EventHandlerArgs) error {
+func (ch *Child) finalizeDepositHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var l1BlockHeight, l1Sequence uint64
 	var from, to, baseDenom string
 	var amount sdk.Coin

--- a/executor/child/handler.go
+++ b/executor/child/handler.go
@@ -1,6 +1,7 @@
 package child
 
 import (
+	"context"
 	"time"
 
 	btypes "github.com/initia-labs/opinit-bots-go/node/broadcaster/types"
@@ -8,7 +9,7 @@ import (
 	"github.com/initia-labs/opinit-bots-go/types"
 )
 
-func (ch *Child) beginBlockHandler(args nodetypes.BeginBlockArgs) (err error) {
+func (ch *Child) beginBlockHandler(ctx context.Context, args nodetypes.BeginBlockArgs) (err error) {
 	blockHeight := uint64(args.Block.Header.Height)
 	// just to make sure that childMsgQueue is empty
 	if blockHeight == args.LatestHeight && len(ch.msgQueue) != 0 && len(ch.processedMsgs) != 0 {
@@ -20,14 +21,14 @@ func (ch *Child) beginBlockHandler(args nodetypes.BeginBlockArgs) (err error) {
 		return err
 	}
 
-	err = ch.prepareOutput()
+	err = ch.prepareOutput(ctx)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (ch *Child) endBlockHandler(args nodetypes.EndBlockArgs) error {
+func (ch *Child) endBlockHandler(_ context.Context, args nodetypes.EndBlockArgs) error {
 	blockHeight := uint64(args.Block.Header.Height)
 	batchKVs := make([]types.RawKV, 0)
 	treeKVs, storageRoot, err := ch.handleTree(blockHeight, args.LatestHeight, args.BlockID, args.Block.Header)

--- a/executor/child/msgs.go
+++ b/executor/child/msgs.go
@@ -1,8 +1,9 @@
 package child
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (ch Child) GetMsgFinalizeTokenDeposit(

--- a/executor/child/oracle.go
+++ b/executor/child/oracle.go
@@ -1,6 +1,7 @@
 package child
 
 import (
+	"context"
 	"strconv"
 
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
@@ -9,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (ch *Child) updateOracleHandler(args nodetypes.EventHandlerArgs) error {
+func (ch *Child) updateOracleHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var l1BlockHeight uint64
 	var from string
 	var err error

--- a/executor/child/oracle.go
+++ b/executor/child/oracle.go
@@ -28,7 +28,7 @@ func (ch *Child) updateOracleHandler(_ context.Context, args nodetypes.EventHand
 	}
 
 	ch.handleUpdateOracle(l1BlockHeight, from)
-
+	ch.lastUpdatedOracleL1Height = l1BlockHeight
 	return nil
 }
 

--- a/executor/child/query.go
+++ b/executor/child/query.go
@@ -1,6 +1,7 @@
 package child
 
 import (
+	"context"
 	"encoding/json"
 
 	"cosmossdk.io/math"
@@ -19,9 +20,9 @@ func (ch Child) GetAddressStr() (string, error) {
 	return ch.node.MustGetBroadcaster().GetAddressString()
 }
 
-func (ch Child) QueryBridgeInfo() (opchildtypes.BridgeInfo, error) {
+func (ch Child) QueryBridgeInfo(ctx context.Context) (opchildtypes.BridgeInfo, error) {
 	req := &opchildtypes.QueryBridgeInfoRequest{}
-	ctx, cancel := rpcclient.GetQueryContext(0)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 
 	res, err := ch.opchildQueryClient.BridgeInfo(ctx, req)
@@ -31,9 +32,9 @@ func (ch Child) QueryBridgeInfo() (opchildtypes.BridgeInfo, error) {
 	return res.BridgeInfo, nil
 }
 
-func (ch Child) QueryNextL1Sequence() (uint64, error) {
+func (ch Child) QueryNextL1Sequence(ctx context.Context) (uint64, error) {
 	req := &opchildtypes.QueryNextL1SequenceRequest{}
-	ctx, cancel := rpcclient.GetQueryContext(0)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 
 	res, err := ch.opchildQueryClient.NextL1Sequence(ctx, req)
@@ -43,9 +44,9 @@ func (ch Child) QueryNextL1Sequence() (uint64, error) {
 	return res.NextL1Sequence, nil
 }
 
-func (ch Child) QueryNextL2Sequence(height uint64) (uint64, error) {
+func (ch Child) QueryNextL2Sequence(ctx context.Context, height uint64) (uint64, error) {
 	req := &opchildtypes.QueryNextL2SequenceRequest{}
-	ctx, cancel := rpcclient.GetQueryContext(height)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, height)
 	defer cancel()
 
 	res, err := ch.opchildQueryClient.NextL2Sequence(ctx, req)

--- a/executor/child/query.go
+++ b/executor/child/query.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	executortypes "github.com/initia-labs/opinit-bots-go/executor/types"
 	"github.com/initia-labs/opinit-bots-go/node/rpcclient"

--- a/executor/child/status.go
+++ b/executor/child/status.go
@@ -1,0 +1,31 @@
+package child
+
+import (
+	"time"
+
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+)
+
+type Status struct {
+	Node                              nodetypes.Status `json:"node"`
+	LastUpdatedOracleL1Height         uint64           `json:"last_updated_oracle_height"`
+	LastFinalizedDepositL1BlockHeight uint64           `json:"last_finalized_deposit_l1_block_height"`
+	LastFinalizedDepositL1Sequence    uint64           `json:"last_finalized_deposit_l1_sequence"`
+	LastWithdrawalL2Sequence          uint64           `json:"last_withdrawal_l2_sequence"`
+	WorkingTreeIndex                  uint64           `json:"working_tree_index"`
+	LastOutputSubmissionTime          time.Time        `json:"last_output_submission_time"`
+	NextOutputSubmissionTime          time.Time        `json:"next_output_submission_time"`
+}
+
+func (ch Child) GetStatus() Status {
+	return Status{
+		Node:                              ch.node.GetStatus(),
+		LastUpdatedOracleL1Height:         ch.lastUpdatedOracleL1Height,
+		LastFinalizedDepositL1BlockHeight: ch.lastFinalizedDepositL1BlockHeight,
+		LastFinalizedDepositL1Sequence:    ch.lastFinalizedDepositL1Sequence,
+		LastWithdrawalL2Sequence:          ch.mk.GetWorkingTreeLeafCount() + ch.mk.GetStartLeafIndex(),
+		WorkingTreeIndex:                  ch.mk.GetWorkingTreeIndex(),
+		LastOutputSubmissionTime:          ch.lastOutputTime,
+		NextOutputSubmissionTime:          ch.nextOutputTime,
+	}
+}

--- a/executor/child/withdraw.go
+++ b/executor/child/withdraw.go
@@ -86,8 +86,14 @@ func (ch *Child) handleInitiateWithdrawal(l2Sequence uint64, from string, to str
 }
 
 func (ch *Child) prepareTree(blockHeight uint64) error {
-	if blockHeight == 1 {
-		return ch.mk.InitializeWorkingTree(1, 1)
+	if ch.startTreeIndex != 0 {
+		ch.logger.Info("initiate tree", zap.Uint64("index", ch.startTreeIndex))
+		err := ch.mk.InitializeWorkingTree(ch.startTreeIndex, 1)
+		if err != nil {
+			return err
+		}
+		ch.startTreeIndex = 0
+		return nil
 	}
 
 	err := ch.mk.LoadWorkingTree(blockHeight - 1)

--- a/executor/child/withdraw.go
+++ b/executor/child/withdraw.go
@@ -100,7 +100,6 @@ func (ch *Child) prepareTree(blockHeight uint64) error {
 	err := ch.mk.LoadWorkingTree(blockHeight - 1)
 	if err == dbtypes.ErrNotFound {
 		// must not happened
-		// TODO: if user want to start from a specific height, we need to provide a way to do so
 		panic(fmt.Errorf("working tree not found at height: %d, current: %d", blockHeight-1, blockHeight))
 	} else if err != nil {
 		return err

--- a/executor/child/withdraw.go
+++ b/executor/child/withdraw.go
@@ -169,6 +169,7 @@ func (ch *Child) handleTree(blockHeight uint64, latestHeight uint64, blockId []b
 
 		ch.finalizingBlockHeight = 0
 		ch.nextOutputTime = blockHeader.Time.Add(ch.bridgeInfo.BridgeConfig.SubmissionInterval * 2 / 3)
+		ch.lastOutputTime = blockHeader.Time
 	}
 
 	err = ch.mk.SaveWorkingTree(blockHeight)

--- a/executor/child/withdraw.go
+++ b/executor/child/withdraw.go
@@ -87,14 +87,12 @@ func (ch *Child) handleInitiateWithdrawal(l2Sequence uint64, from string, to str
 }
 
 func (ch *Child) prepareTree(blockHeight uint64) error {
-	if ch.startTreeIndex != 0 {
-		ch.logger.Info("initiate tree", zap.Uint64("index", ch.startTreeIndex))
-		err := ch.mk.InitializeWorkingTree(ch.startTreeIndex, 1)
-		if err != nil {
-			return err
-		}
-		ch.startTreeIndex = 0
-		return nil
+	if ch.initializeTreeFn != nil {
+		var err error
+		ch.initializeTree.Do(func() {
+			err = ch.initializeTreeFn()
+		})
+		return err
 	}
 
 	err := ch.mk.LoadWorkingTree(blockHeight - 1)

--- a/executor/child/withdraw.go
+++ b/executor/child/withdraw.go
@@ -113,7 +113,7 @@ func (ch *Child) prepareOutput() error {
 
 	// initialize next output time
 	if ch.nextOutputTime.IsZero() && workingOutputIndex > 1 {
-		output, err := ch.host.QueryOutput(workingOutputIndex - 1)
+		output, err := ch.host.QueryOutput(ch.BridgeId(), workingOutputIndex-1)
 		if err != nil {
 			// TODO: maybe not return error here and roll back
 			return fmt.Errorf("output does not exist at index: %d", workingOutputIndex-1)
@@ -122,7 +122,7 @@ func (ch *Child) prepareOutput() error {
 		ch.nextOutputTime = output.OutputProposal.L1BlockTime.Add(ch.bridgeInfo.BridgeConfig.SubmissionInterval * 2 / 3)
 	}
 
-	output, err := ch.host.QueryOutput(ch.mk.GetWorkingTreeIndex())
+	output, err := ch.host.QueryOutput(ch.BridgeId(), ch.mk.GetWorkingTreeIndex())
 	if err != nil {
 		if strings.Contains(err.Error(), "collections: not found") {
 			return nil

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -211,5 +211,11 @@ func (ex *Executor) getStartHeights() (l1StartHeight uint64, l2StartHeight uint6
 	if ex.cfg.L2StartHeight != 0 {
 		l1StartHeight, l2StartHeight, err = ex.host.QueryHeightsOfOutputTxWithL2BlockNumber(uint64(ex.cfg.L2StartHeight))
 	}
-	return l1StartHeight, l2StartHeight, uint64(ex.cfg.BatchStartHeight), err
+
+	if ex.cfg.BatchStartWithL2Height {
+		batchStartHeight = l2StartHeight
+	} else {
+		batchStartHeight = uint64(ex.cfg.BatchStartHeight)
+	}
+	return l1StartHeight, l2StartHeight, batchStartHeight, err
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -239,11 +239,6 @@ func (ex *Executor) getStartHeights(ctx context.Context, bridgeId uint64) (l1Sta
 	if l1StartHeight > depositTxHeight {
 		l1StartHeight = depositTxHeight
 	}
-
-	if ex.cfg.BatchStartWithL2Height {
-		batchStartHeight = l2StartHeight
-	} else {
-		batchStartHeight = uint64(ex.cfg.BatchStartHeight) - 1
-	}
+	batchStartHeight = uint64(ex.cfg.BatchStartHeight) - 1
 	return l1StartHeight, l2StartHeight, startOutputIndex, batchStartHeight, err
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -87,7 +87,7 @@ func NewExecutor(cfg *executortypes.Config, db types.DB, sv *server.Server, logg
 		zap.Duration("submission_interval", bridgeInfo.BridgeConfig.SubmissionInterval),
 	)
 
-	hostStartHeight, childStartHeight, batchStartHeight, err := executor.getStartHeights()
+	hostStartHeight, childStartHeight, startOutputIndex, batchStartHeight, err := executor.getStartHeights(int64(bridgeInfo.BridgeId))
 	if err != nil {
 		panic(err)
 	}
@@ -96,7 +96,7 @@ func NewExecutor(cfg *executortypes.Config, db types.DB, sv *server.Server, logg
 	if err != nil {
 		panic(err)
 	}
-	err = executor.child.Initialize(childStartHeight, executor.host, bridgeInfo)
+	err = executor.child.Initialize(childStartHeight, startOutputIndex, executor.host, bridgeInfo)
 	if err != nil {
 		panic(err)
 	}
@@ -207,9 +207,9 @@ func (ex *Executor) makeDANode(bridgeId int64) (executortypes.DANode, error) {
 	return nil, fmt.Errorf("unsupported chain id for DA: %s", ophosttypes.BatchInfo_ChainType_name[int32(batchInfo.BatchInfo.ChainType)])
 }
 
-func (ex *Executor) getStartHeights() (l1StartHeight uint64, l2StartHeight uint64, batchStartHeight uint64, err error) {
+func (ex *Executor) getStartHeights(bridgeId int64) (l1StartHeight uint64, l2StartHeight uint64, startOutputIndex uint64, batchStartHeight uint64, err error) {
 	if ex.cfg.L2StartHeight != 0 {
-		l1StartHeight, l2StartHeight, err = ex.host.QueryHeightsOfOutputTxWithL2BlockNumber(uint64(ex.cfg.L2StartHeight))
+		l1StartHeight, l2StartHeight, startOutputIndex, err = ex.host.QueryHeightsOfOutputTxWithL2BlockNumber(bridgeId, uint64(ex.cfg.L2StartHeight))
 	}
 
 	if ex.cfg.BatchStartWithL2Height {
@@ -217,5 +217,5 @@ func (ex *Executor) getStartHeights() (l1StartHeight uint64, l2StartHeight uint6
 	} else {
 		batchStartHeight = uint64(ex.cfg.BatchStartHeight)
 	}
-	return l1StartHeight, l2StartHeight, batchStartHeight, err
+	return l1StartHeight, l2StartHeight, startOutputIndex, batchStartHeight, err
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -163,14 +163,7 @@ func (ex *Executor) RegisterQuerier() {
 	})
 
 	ex.server.RegisterQuerier("/status", func(c *fiber.Ctx) error {
-		childHeight := ex.child.GetHeight()
-		hostHeight := ex.host.GetHeight()
-		res := map[string]uint64{
-			"child": childHeight,
-			"host":  hostHeight,
-		}
-
-		return c.JSON(res)
+		return c.JSON(ex.GetStatus())
 	})
 }
 

--- a/executor/host/batch.go
+++ b/executor/host/batch.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"strconv"
 
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
@@ -8,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *Host) recordBatchHandler(args nodetypes.EventHandlerArgs) error {
+func (h *Host) recordBatchHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var submitter string
 	for _, attr := range args.EventAttributes {
 		switch attr.Key {
@@ -29,7 +30,7 @@ func (h *Host) recordBatchHandler(args nodetypes.EventHandlerArgs) error {
 	return nil
 }
 
-func (h *Host) updateBatchInfoHandler(args nodetypes.EventHandlerArgs) error {
+func (h *Host) updateBatchInfoHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var bridgeId uint64
 	var submitter, chain string
 	var outputIndex, l2BlockNumber uint64

--- a/executor/host/deposit.go
+++ b/executor/host/deposit.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"strconv"
@@ -12,7 +13,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (h *Host) initiateDepositHandler(args nodetypes.EventHandlerArgs) error {
+func (h *Host) initiateDepositHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var bridgeId uint64
 	var l1Sequence uint64
 	var from, to, l1Denom, l2Denom, amount string

--- a/executor/host/handler.go
+++ b/executor/host/handler.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"time"
 
 	"github.com/initia-labs/opinit-bots-go/types"
@@ -11,7 +12,7 @@ import (
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 )
 
-func (h *Host) beginBlockHandler(args nodetypes.BeginBlockArgs) error {
+func (h *Host) beginBlockHandler(_ context.Context, args nodetypes.BeginBlockArgs) error {
 	blockHeight := uint64(args.Block.Header.Height)
 	// just to make sure that childMsgQueue is empty
 	if blockHeight == args.LatestHeight && len(h.msgQueue) != 0 && len(h.processedMsgs) != 0 {
@@ -20,7 +21,7 @@ func (h *Host) beginBlockHandler(args nodetypes.BeginBlockArgs) error {
 	return nil
 }
 
-func (h *Host) endBlockHandler(args nodetypes.EndBlockArgs) error {
+func (h *Host) endBlockHandler(_ context.Context, args nodetypes.EndBlockArgs) error {
 	// temporary 50 limit for msg queue
 	// collect more msgs if block height is not latest
 	blockHeight := uint64(args.Block.Header.Height)
@@ -61,7 +62,7 @@ func (h *Host) endBlockHandler(args nodetypes.EndBlockArgs) error {
 	return nil
 }
 
-func (h *Host) txHandler(args nodetypes.TxHandlerArgs) error {
+func (h *Host) txHandler(_ context.Context, args nodetypes.TxHandlerArgs) error {
 	if args.BlockHeight == args.LatestHeight && args.TxIndex == 0 {
 		if msg, err := h.oracleTxHandler(args.BlockHeight, args.Tx); err != nil {
 			return err

--- a/executor/host/host.go
+++ b/executor/host/host.go
@@ -26,7 +26,7 @@ type childNode interface {
 	HasKey() bool
 	BroadcastMsgs(btypes.ProcessedMsgs)
 	ProcessedMsgsToRawKV([]btypes.ProcessedMsgs, bool) ([]types.RawKV, error)
-	QueryNextL1Sequence() (uint64, error)
+	QueryNextL1Sequence(context.Context) (uint64, error)
 
 	GetMsgFinalizeTokenDeposit(string, string, sdk.Coin, uint64, uint64, string, []byte) (sdk.Msg, error)
 	GetMsgUpdateOracle(
@@ -111,7 +111,7 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (h *Host) Initialize(startHeight uint64, child childNode, batch batchNode, bridgeId int64) error {
+func (h *Host) Initialize(ctx context.Context, startHeight uint64, child childNode, batch batchNode, bridgeId int64) error {
 	err := h.node.Initialize(startHeight)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func (h *Host) Initialize(startHeight uint64, child childNode, batch batchNode, 
 	h.batch = batch
 	h.bridgeId = bridgeId
 
-	h.initialL1Sequence, err = h.child.QueryNextL1Sequence()
+	h.initialL1Sequence, err = h.child.QueryNextL1Sequence(ctx)
 	if err != nil {
 		return err
 	}

--- a/executor/host/host.go
+++ b/executor/host/host.go
@@ -60,6 +60,10 @@ type Host struct {
 
 	processedMsgs []btypes.ProcessedMsgs
 	msgQueue      []sdk.Msg
+
+	// status info
+	lastProposedOutputIndex         uint64
+	lastProposedOutputL2BlockNumber uint64
 }
 
 func NewHost(

--- a/executor/host/host.go
+++ b/executor/host/host.go
@@ -111,7 +111,11 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (h *Host) Initialize(child childNode, batch batchNode, bridgeId int64) (err error) {
+func (h *Host) Initialize(startHeight uint64, child childNode, batch batchNode, bridgeId int64) error {
+	err := h.node.Initialize(startHeight)
+	if err != nil {
+		return err
+	}
 	h.child = child
 	h.batch = batch
 	h.bridgeId = bridgeId

--- a/executor/host/msgs.go
+++ b/executor/host/msgs.go
@@ -1,8 +1,9 @@
 package host
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (h Host) GetMsgProposeOutput(

--- a/executor/host/query.go
+++ b/executor/host/query.go
@@ -1,9 +1,12 @@
 package host
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	query "github.com/cosmos/cosmos-sdk/types/query"
@@ -11,6 +14,7 @@ import (
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
 
 	"github.com/initia-labs/opinit-bots-go/node/rpcclient"
+	"github.com/initia-labs/opinit-bots-go/types"
 )
 
 func (h Host) GetAddress() sdk.AccAddress {
@@ -21,7 +25,7 @@ func (h Host) GetAddressStr() (string, error) {
 	return h.node.MustGetBroadcaster().GetAddressString()
 }
 
-func (h Host) QueryLastOutput(bridgeId uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
+func (h Host) QueryLastOutput(ctx context.Context, bridgeId uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
 	req := &ophosttypes.QueryOutputProposalsRequest{
 		BridgeId: bridgeId,
 		Pagination: &query.PageRequest{
@@ -29,7 +33,7 @@ func (h Host) QueryLastOutput(bridgeId uint64) (*ophosttypes.QueryOutputProposal
 			Reverse: true,
 		},
 	}
-	ctx, cancel := rpcclient.GetQueryContext(0)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 
 	res, err := h.ophostQueryClient.OutputProposals(ctx, req)
@@ -42,27 +46,27 @@ func (h Host) QueryLastOutput(bridgeId uint64) (*ophosttypes.QueryOutputProposal
 	return &res.OutputProposals[0], nil
 }
 
-func (h Host) QueryOutput(bridgeId uint64, outputIndex uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
+func (h Host) QueryOutput(ctx context.Context, bridgeId uint64, outputIndex uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
 	req := &ophosttypes.QueryOutputProposalRequest{
 		BridgeId:    bridgeId,
 		OutputIndex: outputIndex,
 	}
-	ctx, cancel := rpcclient.GetQueryContext(0)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 
 	return h.ophostQueryClient.OutputProposal(ctx, req)
 }
 
 // QueryOutputByL2BlockNumber queries the last output proposal before the given L2 block number
-func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
-	start, err := h.QueryOutput(bridgeId, 1)
+func (h Host) QueryOutputByL2BlockNumber(ctx context.Context, bridgeId uint64, l2BlockNumber uint64) (*ophosttypes.QueryOutputProposalResponse, error) {
+	start, err := h.QueryOutput(ctx, bridgeId, 1)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return nil, nil
 		}
 		return nil, err
 	}
-	end, err := h.QueryLastOutput(bridgeId)
+	end, err := h.QueryLastOutput(ctx, bridgeId)
 	if err != nil {
 		return nil, err
 	} else if end == nil {
@@ -72,7 +76,7 @@ func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) 
 	for {
 		if start.OutputProposal.L2BlockNumber >= l2BlockNumber {
 			if start.OutputIndex != 1 {
-				return h.QueryOutput(bridgeId, start.OutputIndex-1)
+				return h.QueryOutput(ctx, bridgeId, start.OutputIndex-1)
 			}
 			return nil, nil
 		} else if end.OutputProposal.L2BlockNumber < l2BlockNumber {
@@ -82,7 +86,7 @@ func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) 
 		}
 
 		midIndex := (start.OutputIndex + end.OutputIndex) / 2
-		output, err := h.QueryOutput(bridgeId, midIndex)
+		output, err := h.QueryOutput(ctx, bridgeId, midIndex)
 		if err != nil {
 			return nil, err
 		}
@@ -95,8 +99,8 @@ func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) 
 	}
 }
 
-func (h Host) QueryCreateBridgeHeight(bridgeId uint64) (uint64, error) {
-	ctx, cancel := rpcclient.GetQueryContext(0)
+func (h Host) QueryCreateBridgeHeight(ctx context.Context, bridgeId uint64) (uint64, error) {
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 
 	query := fmt.Sprintf("%s.%s = %d",
@@ -116,11 +120,59 @@ func (h Host) QueryCreateBridgeHeight(bridgeId uint64) (uint64, error) {
 	return uint64(res.Txs[0].Height), nil
 }
 
-func (h Host) QueryBatchInfos(bridgeId uint64) (*ophosttypes.QueryBatchInfosResponse, error) {
+func (h Host) QueryBatchInfos(ctx context.Context, bridgeId uint64) (*ophosttypes.QueryBatchInfosResponse, error) {
 	req := &ophosttypes.QueryBatchInfosRequest{
 		BridgeId: bridgeId,
 	}
-	ctx, cancel := rpcclient.GetQueryContext(0)
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
 	defer cancel()
 	return h.ophostQueryClient.BatchInfos(ctx, req)
+}
+
+func (h Host) QueryDepositTxHeight(ctx context.Context, bridgeId uint64, l1Sequence uint64) (uint64, error) {
+	if l1Sequence == 0 {
+		return 0, nil
+	}
+
+	ctx, cancel := rpcclient.GetQueryContext(ctx, 0)
+	defer cancel()
+
+	ticker := time.NewTicker(types.PollingInterval(ctx))
+	defer ticker.Stop()
+
+	query := fmt.Sprintf("%s.%s = %d",
+		ophosttypes.EventTypeInitiateTokenDeposit,
+		ophosttypes.AttributeKeyL1Sequence,
+		l1Sequence,
+	)
+	per_page := 100
+	for page := 1; ; page++ {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-ticker.C:
+		}
+
+		res, err := h.node.GetRPCClient().TxSearch(ctx, query, false, &page, &per_page, "asc")
+		if err != nil {
+			return 0, err
+		}
+
+		for _, tx := range res.Txs {
+			for _, event := range tx.TxResult.Events {
+				if event.Type == ophosttypes.EventTypeInitiateTokenDeposit {
+					for _, attr := range event.Attributes {
+						if attr.Key == ophosttypes.AttributeKeyBridgeId && attr.Value == strconv.FormatUint(bridgeId, 10) {
+							return uint64(tx.Height), nil
+						}
+					}
+				}
+			}
+		}
+
+		if page*per_page >= res.TotalCount {
+			break
+		}
+	}
+	return 0, fmt.Errorf("failed to fetch deposit tx with l1 Sequence: %d", l1Sequence)
 }

--- a/executor/host/query.go
+++ b/executor/host/query.go
@@ -61,45 +61,48 @@ func (h Host) QueryBatchInfos() (*ophosttypes.QueryBatchInfosResponse, error) {
 	return h.ophostQueryClient.BatchInfos(ctx, req)
 }
 
-func (h Host) QueryHeightsOfOutputTxWithL2BlockNumber(l2BlockNumber uint64) (uint64, uint64, error) {
+func (h Host) QueryHeightsOfOutputTxWithL2BlockNumber(bridgeId int64, l2BlockNumber uint64) (uint64, uint64, uint64, error) {
 	ctx, cancel := rpcclient.GetQueryContext(0)
 	defer cancel()
 
 	query := fmt.Sprintf("%s.%s = %d AND %s.%s <= %d", ophosttypes.EventTypeProposeOutput,
 		ophosttypes.AttributeKeyBridgeId,
-		h.bridgeId,
+		bridgeId,
 		ophosttypes.EventTypeProposeOutput,
 		ophosttypes.AttributeKeyL2BlockNumber,
 		l2BlockNumber,
 	)
-
 	perPage := 1
 	res, err := h.node.GetRPCClient().TxSearch(ctx, query, false, nil, &perPage, "desc")
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	if len(res.Txs) == 0 {
 		// no output tx found
-		return 0, 0, nil
+		return 0, 0, 0, nil
 	}
 
 	l2StartHeight := uint64(0)
-LOOP:
+	outputIndex := uint64(0)
 	for _, event := range res.Txs[0].TxResult.Events {
 		if event.Type == ophosttypes.EventTypeProposeOutput {
 			for _, attr := range event.Attributes {
 				if attr.Key == ophosttypes.AttributeKeyL2BlockNumber {
 					l2StartHeight, err = strconv.ParseUint(attr.Value, 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, 0, err
 					}
-					break LOOP
+				} else if attr.Key == ophosttypes.AttributeKeyOutputIndex {
+					outputIndex, err = strconv.ParseUint(attr.Value, 10, 64)
+					if err != nil {
+						return 0, 0, 0, err
+					}
 				}
 			}
 		}
 	}
-	if l2StartHeight == 0 {
-		return 0, 0, fmt.Errorf("something wrong: l2 block number not found in the output tx")
+	if l2StartHeight == 0 || outputIndex == 0 {
+		return 0, 0, 0, fmt.Errorf("something wrong: l2 block number not found in the output tx")
 	}
-	return uint64(res.Txs[0].Height), l2StartHeight, nil
+	return uint64(res.Txs[0].Height), l2StartHeight, outputIndex + 1, nil
 }

--- a/executor/host/query.go
+++ b/executor/host/query.go
@@ -79,7 +79,7 @@ func (h Host) QueryHeightsOfOutputTxWithL2BlockNumber(bridgeId int64, l2BlockNum
 	}
 	if len(res.Txs) == 0 {
 		// no output tx found
-		return 0, 0, 0, nil
+		return 0, 0, 1, nil
 	}
 
 	l2StartHeight := uint64(0)

--- a/executor/host/query.go
+++ b/executor/host/query.go
@@ -1,6 +1,9 @@
 package host
 
 import (
+	"fmt"
+	"strconv"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	query "github.com/cosmos/cosmos-sdk/types/query"
 
@@ -56,4 +59,47 @@ func (h Host) QueryBatchInfos() (*ophosttypes.QueryBatchInfosResponse, error) {
 	ctx, cancel := rpcclient.GetQueryContext(0)
 	defer cancel()
 	return h.ophostQueryClient.BatchInfos(ctx, req)
+}
+
+func (h Host) QueryHeightsOfOutputTxWithL2BlockNumber(l2BlockNumber uint64) (uint64, uint64, error) {
+	ctx, cancel := rpcclient.GetQueryContext(0)
+	defer cancel()
+
+	query := fmt.Sprintf("%s.%s = %d AND %s.%s <= %d", ophosttypes.EventTypeProposeOutput,
+		ophosttypes.AttributeKeyBridgeId,
+		h.bridgeId,
+		ophosttypes.EventTypeProposeOutput,
+		ophosttypes.AttributeKeyL2BlockNumber,
+		l2BlockNumber,
+	)
+
+	perPage := 1
+	res, err := h.node.GetRPCClient().TxSearch(ctx, query, false, nil, &perPage, "desc")
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(res.Txs) == 0 {
+		// no output tx found
+		return 0, 0, nil
+	}
+
+	l2StartHeight := uint64(0)
+LOOP:
+	for _, event := range res.Txs[0].TxResult.Events {
+		if event.Type == ophosttypes.EventTypeProposeOutput {
+			for _, attr := range event.Attributes {
+				if attr.Key == ophosttypes.AttributeKeyL2BlockNumber {
+					l2StartHeight, err = strconv.ParseUint(attr.Value, 10, 64)
+					if err != nil {
+						return 0, 0, err
+					}
+					break LOOP
+				}
+			}
+		}
+	}
+	if l2StartHeight == 0 {
+		return 0, 0, fmt.Errorf("something wrong: l2 block number not found in the output tx")
+	}
+	return uint64(res.Txs[0].Height), l2StartHeight, nil
 }

--- a/executor/host/query.go
+++ b/executor/host/query.go
@@ -71,6 +71,9 @@ func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) 
 
 	for {
 		if start.OutputProposal.L2BlockNumber >= l2BlockNumber {
+			if start.OutputIndex != 1 {
+				return h.QueryOutput(bridgeId, start.OutputIndex-1)
+			}
 			return nil, nil
 		} else if end.OutputProposal.L2BlockNumber < l2BlockNumber {
 			return end, nil
@@ -84,9 +87,7 @@ func (h Host) QueryOutputByL2BlockNumber(bridgeId uint64, l2BlockNumber uint64) 
 			return nil, err
 		}
 
-		if output.OutputProposal.L2BlockNumber == l2BlockNumber {
-			return output, nil
-		} else if output.OutputProposal.L2BlockNumber < l2BlockNumber {
+		if output.OutputProposal.L2BlockNumber <= l2BlockNumber {
 			start = output
 		} else {
 			end = output

--- a/executor/host/status.go
+++ b/executor/host/status.go
@@ -1,0 +1,23 @@
+package host
+
+import (
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+)
+
+type Status struct {
+	Node                            nodetypes.Status `json:"node"`
+	LastProposedOutputIndex         uint64           `json:"last_proposed_output_index"`
+	LastProposedOutputL2BlockNumber uint64           `json:"last_proposed_output_l2_block_number"`
+}
+
+func (h Host) GetStatus() Status {
+	return Status{
+		Node:                            h.node.GetStatus(),
+		LastProposedOutputIndex:         h.lastProposedOutputIndex,
+		LastProposedOutputL2BlockNumber: h.lastProposedOutputL2BlockNumber,
+	}
+}
+
+func (h Host) GetNodeStatus() nodetypes.Status {
+	return h.node.GetStatus()
+}

--- a/executor/host/withdraw.go
+++ b/executor/host/withdraw.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"strconv"
@@ -10,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *Host) proposeOutputHandler(args nodetypes.EventHandlerArgs) error {
+func (h *Host) proposeOutputHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var bridgeId, l2BlockNumber, outputIndex uint64
 	var proposer string
 	var outputRoot []byte
@@ -58,7 +59,7 @@ func (h *Host) handleProposeOutput(bridgeId uint64, proposer string, outputIndex
 	)
 }
 
-func (h *Host) finalizeWithdrawalHandler(args nodetypes.EventHandlerArgs) error {
+func (h *Host) finalizeWithdrawalHandler(_ context.Context, args nodetypes.EventHandlerArgs) error {
 	var bridgeId uint64
 	var outputIndex, l2Sequence uint64
 	var from, to, l1Denom, l2Denom, amount string

--- a/executor/host/withdraw.go
+++ b/executor/host/withdraw.go
@@ -45,7 +45,8 @@ func (h *Host) proposeOutputHandler(_ context.Context, args nodetypes.EventHandl
 	}
 
 	h.handleProposeOutput(bridgeId, proposer, outputIndex, l2BlockNumber, outputRoot)
-
+	h.lastProposedOutputIndex = outputIndex
+	h.lastProposedOutputL2BlockNumber = l2BlockNumber
 	return nil
 }
 

--- a/executor/status.go
+++ b/executor/status.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"github.com/initia-labs/opinit-bots-go/executor/batch"
+	"github.com/initia-labs/opinit-bots-go/executor/child"
+	"github.com/initia-labs/opinit-bots-go/executor/host"
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+)
+
+type Status struct {
+	BridgeId int64            `json:"bridge_id"`
+	Host     host.Status      `json:"host"`
+	Child    child.Status     `json:"child"`
+	Batch    batch.Status     `json:"batch"`
+	DA       nodetypes.Status `json:"da"`
+}
+
+func (e Executor) GetStatus() Status {
+	return Status{
+		BridgeId: e.host.BridgeId(),
+		Host:     e.host.GetStatus(),
+		Child:    e.child.GetStatus(),
+		Batch:    e.batch.GetStatus(),
+		DA:       e.batch.DA().GetNodeStatus(),
+	}
+}

--- a/executor/status.go
+++ b/executor/status.go
@@ -9,18 +9,27 @@ import (
 
 type Status struct {
 	BridgeId int64            `json:"bridge_id"`
-	Host     host.Status      `json:"host"`
-	Child    child.Status     `json:"child"`
-	Batch    batch.Status     `json:"batch"`
-	DA       nodetypes.Status `json:"da"`
+	Host     host.Status      `json:"host,omitempty"`
+	Child    child.Status     `json:"child,omitempty"`
+	Batch    batch.Status     `json:"batch,omitempty"`
+	DA       nodetypes.Status `json:"da,omitempty"`
 }
 
-func (e Executor) GetStatus() Status {
-	return Status{
-		BridgeId: e.host.BridgeId(),
-		Host:     e.host.GetStatus(),
-		Child:    e.child.GetStatus(),
-		Batch:    e.batch.GetStatus(),
-		DA:       e.batch.DA().GetNodeStatus(),
+func (ex Executor) GetStatus() Status {
+	s := Status{
+		BridgeId: ex.host.BridgeId(),
 	}
+	if ex.host != nil {
+		s.Host = ex.host.GetStatus()
+	}
+	if ex.child != nil {
+		s.Child = ex.child.GetStatus()
+	}
+	if ex.batch != nil {
+		s.Batch = ex.batch.GetStatus()
+		if ex.batch.DA() != nil {
+			s.DA = ex.batch.DA().GetNodeStatus()
+		}
+	}
+	return s
 }

--- a/executor/types/batch.go
+++ b/executor/types/batch.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	btypes "github.com/initia-labs/opinit-bots-go/node/broadcaster/types"
+	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 	"github.com/initia-labs/opinit-bots-go/types"
 )
 
@@ -14,6 +15,7 @@ type DANode interface {
 	CreateBatchMsg([]byte) (sdk.Msg, error)
 	BroadcastMsgs(btypes.ProcessedMsgs)
 	ProcessedMsgsToRawKV(processedMsgs []btypes.ProcessedMsgs, delete bool) ([]types.RawKV, error)
+	GetNodeStatus() nodetypes.Status
 }
 
 // BatchHeader is the header of a batch

--- a/executor/types/batch.go
+++ b/executor/types/batch.go
@@ -3,10 +3,11 @@ package types
 import (
 	"context"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	btypes "github.com/initia-labs/opinit-bots-go/node/broadcaster/types"
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 	"github.com/initia-labs/opinit-bots-go/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type DANode interface {

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -71,11 +71,7 @@ type Config struct {
 	// L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
 	// L1 starts from the block number of the output tx + 1
 	L2StartHeight int64 `json:"l2_start_height"`
-	// BatchStartWithL2Height is the flag to start the batch same with the l2 height.
-	// If the latest height stored in the db is not 0, this config is ignored.
-	// If it is true, the batch will start from the last submitted output l2 block number + 1.
-	BatchStartWithL2Height bool `json:"batch_start_with_l2_height"`
-	// StartBatchHeight is the height to start the batch. If it is 0, it will start from the latest height.
+	// BatchStartHeight is the height to start the batch. If it is 0, it will start from the latest height.
 	// If the latest height stored in the db is not 0, this config is ignored.
 	BatchStartHeight int64 `json:"batch_start_height"`
 }
@@ -121,9 +117,8 @@ func DefaultConfig() *Config {
 		MaxChunkSize:      300000,  // 300KB
 		MaxSubmissionTime: 60 * 60, // 1 hour
 
-		L2StartHeight:          0,
-		BatchStartWithL2Height: false,
-		BatchStartHeight:       0,
+		L2StartHeight:    0,
+		BatchStartHeight: 0,
 	}
 }
 

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	// L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
 	// L1 starts from the block number of the output tx + 1
 	L2StartHeight int64 `json:"l2_start_height"`
+	// BatchStartWithL2Height is the flag to start the batch same with the l2 height.
+	// If the latest height stored in the db is not 0, this config is ignored.
+	// If it is true, the batch will start from the last submitted output l2 block number + 1.
+	BatchStartWithL2Height bool `json:"batch_start_with_l2_height"`
 	// StartBatchHeight is the height to start the batch. If it is 0, it will start from the latest height.
 	// If the latest height stored in the db is not 0, this config is ignored.
 	BatchStartHeight int64 `json:"batch_start_height"`
@@ -97,8 +101,9 @@ func DefaultConfig() *Config {
 		MaxChunkSize:      300000,  // 300KB
 		MaxSubmissionTime: 60 * 60, // 1 hour
 
-		L2StartHeight:    0,
-		BatchStartHeight: 0,
+		L2StartHeight:          0,
+		BatchStartWithL2Height: false,
+		BatchStartHeight:       0,
 	}
 }
 

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -2,10 +2,33 @@ package types
 
 import (
 	"errors"
+	"time"
 
 	btypes "github.com/initia-labs/opinit-bots-go/node/broadcaster/types"
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 )
+
+type NodeConfig struct {
+	ChainID       string  `json:"chain_id"`
+	Bech32Prefix  string  `json:"bech32_prefix"`
+	RPCAddress    string  `json:"rpc_address"`
+	GasPrice      string  `json:"gas_price"`
+	GasAdjustment float64 `json:"gas_adjustment"`
+	TxTimeout     int64   `json:"tx_timeout"` // seconds
+}
+
+func (nc NodeConfig) Validate() error {
+	if nc.ChainID == "" {
+		return errors.New("chain ID is required")
+	}
+	if nc.Bech32Prefix == "" {
+		return errors.New("bech32 prefix is required")
+	}
+	if nc.RPCAddress == "" {
+		return errors.New("RPC address is required")
+	}
+	return nil
+}
 
 type Config struct {
 	// Version is the version used to build output root.
@@ -14,21 +37,12 @@ type Config struct {
 	// ListenAddress is the address to listen for incoming requests.
 	ListenAddress string `json:"listen_address"`
 
-	L1RPCAddress string `json:"l1_rpc_address"`
-	L2RPCAddress string `json:"l2_rpc_address"`
-	DARPCAddress string `json:"da_rpc_address"`
-
-	L1GasPrice string `json:"l1_gas_price"`
-	L2GasPrice string `json:"l2_gas_price"`
-	DAGasPrice string `json:"da_gas_price"`
-
-	L1ChainID string `json:"l1_chain_id"`
-	L2ChainID string `json:"l2_chain_id"`
-	DAChainID string `json:"da_chain_id"`
-
-	L1Bech32Prefix string `json:"l1_bech32_prefix"`
-	L2Bech32Prefix string `json:"l2_bech32_prefix"`
-	DABech32Prefix string `json:"da_bech32_prefix"`
+	// L1Node is the configuration for the l1 node.
+	L1Node NodeConfig `json:"l1_node"`
+	// L2Node is the configuration for the l2 node.
+	L2Node NodeConfig `json:"l2_node"`
+	// DANode is the configuration for the data availability node.
+	DANode NodeConfig `json:"da_node"`
 
 	// OutputSubmitter is the key name in the keyring for the output submitter,
 	// which is used to relay the output transaction from l2 to l1.
@@ -66,31 +80,37 @@ type Config struct {
 	BatchStartHeight int64 `json:"batch_start_height"`
 }
 
-type HostConfig struct {
-	nodetypes.NodeConfig
-	RelayOracle bool `json:"relay_oracle"`
-}
-
 func DefaultConfig() *Config {
 	return &Config{
 		Version:       1,
 		ListenAddress: "localhost:3000",
 
-		L1RPCAddress: "tcp://localhost:26657",
-		L2RPCAddress: "tcp://localhost:27657",
-		DARPCAddress: "tcp://localhost:28657",
+		L1Node: NodeConfig{
+			ChainID:       "testnet-l1-1",
+			Bech32Prefix:  "init",
+			RPCAddress:    "tcp://localhost:26657",
+			GasPrice:      "0.15uinit",
+			GasAdjustment: 1.5,
+			TxTimeout:     60,
+		},
 
-		L1GasPrice: "0.15uinit",
-		L2GasPrice: "",
-		DAGasPrice: "",
+		L2Node: NodeConfig{
+			ChainID:       "testnet-l2-1",
+			Bech32Prefix:  "init",
+			RPCAddress:    "tcp://localhost:27657",
+			GasPrice:      "",
+			GasAdjustment: 1.5,
+			TxTimeout:     60,
+		},
 
-		L1ChainID: "testnet-l1-1",
-		L2ChainID: "testnet-l2-1",
-		DAChainID: "testnet-da-1",
-
-		L1Bech32Prefix: "init",
-		L2Bech32Prefix: "init",
-		DABech32Prefix: "init",
+		DANode: NodeConfig{
+			ChainID:       "testnet-l1-1",
+			Bech32Prefix:  "init",
+			RPCAddress:    "tcp://localhost:26657",
+			GasPrice:      "0.15uinit",
+			GasAdjustment: 1.5,
+			TxTimeout:     60,
+		},
 
 		OutputSubmitter: "",
 		BridgeExecutor:  "",
@@ -112,54 +132,37 @@ func (cfg Config) Validate() error {
 		return errors.New("version is required")
 	}
 
-	if cfg.L1RPCAddress == "" {
-		return errors.New("L1 RPC URL is required")
-	}
-	if cfg.L2RPCAddress == "" {
-		return errors.New("L2 RPC URL is required")
-	}
-	if cfg.DARPCAddress == "" {
-		return errors.New("L2 RPC URL is required")
-	}
-
-	if cfg.L1ChainID == "" {
-		return errors.New("L1 chain ID is required")
-	}
-	if cfg.L2ChainID == "" {
-		return errors.New("L2 chain ID is required")
-	}
-	if cfg.DAChainID == "" {
-		return errors.New("DA chain ID is required")
-	}
-
 	if cfg.ListenAddress == "" {
 		return errors.New("listen address is required")
 	}
 
-	if cfg.L1Bech32Prefix == "" {
-		return errors.New("L1 bech32 prefix is required")
-	}
-	if cfg.L2Bech32Prefix == "" {
-		return errors.New("L2 bech32 prefix is required")
-	}
-	if cfg.DABech32Prefix == "" {
-		return errors.New("DA bech32 prefix is required")
+	if err := cfg.L1Node.Validate(); err != nil {
+		return err
 	}
 
+	if err := cfg.L2Node.Validate(); err != nil {
+		return err
+	}
+
+	if err := cfg.DANode.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (cfg Config) L1NodeConfig(homePath string) nodetypes.NodeConfig {
 	nc := nodetypes.NodeConfig{
-		RPC:         cfg.L1RPCAddress,
+		RPC:         cfg.L1Node.RPCAddress,
 		ProcessType: nodetypes.PROCESS_TYPE_DEFAULT,
 	}
 
 	if cfg.OutputSubmitter != "" {
 		nc.BroadcasterConfig = &btypes.BroadcasterConfig{
-			ChainID:      cfg.L1ChainID,
-			GasPrice:     cfg.L1GasPrice,
-			Bech32Prefix: cfg.L1Bech32Prefix,
+			ChainID:       cfg.L1Node.ChainID,
+			GasPrice:      cfg.L1Node.GasPrice,
+			GasAdjustment: cfg.L1Node.GasAdjustment,
+			Bech32Prefix:  cfg.L1Node.Bech32Prefix,
+			TxTimeout:     time.Duration(cfg.L1Node.TxTimeout) * time.Second,
 			KeyringConfig: btypes.KeyringConfig{
 				Name:     cfg.OutputSubmitter,
 				HomePath: homePath,
@@ -172,15 +175,17 @@ func (cfg Config) L1NodeConfig(homePath string) nodetypes.NodeConfig {
 
 func (cfg Config) L2NodeConfig(homePath string) nodetypes.NodeConfig {
 	nc := nodetypes.NodeConfig{
-		RPC:         cfg.L2RPCAddress,
+		RPC:         cfg.L2Node.RPCAddress,
 		ProcessType: nodetypes.PROCESS_TYPE_DEFAULT,
 	}
 
 	if cfg.BridgeExecutor != "" {
 		nc.BroadcasterConfig = &btypes.BroadcasterConfig{
-			ChainID:      cfg.L2ChainID,
-			GasPrice:     cfg.L2GasPrice,
-			Bech32Prefix: cfg.L2Bech32Prefix,
+			ChainID:       cfg.L2Node.ChainID,
+			GasPrice:      cfg.L2Node.GasPrice,
+			GasAdjustment: cfg.L2Node.GasAdjustment,
+			Bech32Prefix:  cfg.L2Node.Bech32Prefix,
+			TxTimeout:     time.Duration(cfg.L2Node.TxTimeout) * time.Second,
 			KeyringConfig: btypes.KeyringConfig{
 				Name:     cfg.BridgeExecutor,
 				HomePath: homePath,
@@ -193,12 +198,14 @@ func (cfg Config) L2NodeConfig(homePath string) nodetypes.NodeConfig {
 
 func (cfg Config) DANodeConfig(homePath string) nodetypes.NodeConfig {
 	nc := nodetypes.NodeConfig{
-		RPC:         cfg.DARPCAddress,
+		RPC:         cfg.DANode.RPCAddress,
 		ProcessType: nodetypes.PROCESS_TYPE_DEFAULT,
 		BroadcasterConfig: &btypes.BroadcasterConfig{
-			ChainID:      cfg.DAChainID,
-			GasPrice:     cfg.DAGasPrice,
-			Bech32Prefix: cfg.DABech32Prefix,
+			ChainID:       cfg.DANode.ChainID,
+			GasPrice:      cfg.DANode.GasPrice,
+			GasAdjustment: cfg.DANode.GasAdjustment,
+			Bech32Prefix:  cfg.DANode.Bech32Prefix,
+			TxTimeout:     time.Duration(cfg.DANode.TxTimeout) * time.Second,
 			KeyringConfig: btypes.KeyringConfig{
 				HomePath: homePath,
 			},

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -51,6 +51,15 @@ type Config struct {
 	MaxChunkSize int64 `json:"max_chunk_size"`
 	// MaxSubmissionTime is the maximum time to submit a batch.
 	MaxSubmissionTime int64 `json:"max_submission_time"` // seconds
+
+	// L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
+	// If the latest height stored in the db is not 0, this config is ignored.
+	// L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
+	// L1 starts from the block number of the output tx + 1
+	L2StartHeight int64 `json:"l2_start_height"`
+	// StartBatchHeight is the height to start the batch. If it is 0, it will start from the latest height.
+	// If the latest height stored in the db is not 0, this config is ignored.
+	BatchStartHeight int64 `json:"batch_start_height"`
 }
 
 type HostConfig struct {
@@ -73,7 +82,7 @@ func DefaultConfig() *Config {
 
 		L1ChainID: "testnet-l1-1",
 		L2ChainID: "testnet-l2-1",
-		DAChainID: "testnet-l3-1",
+		DAChainID: "testnet-da-1",
 
 		L1Bech32Prefix: "init",
 		L2Bech32Prefix: "init",
@@ -87,6 +96,9 @@ func DefaultConfig() *Config {
 		MaxChunks:         5000,
 		MaxChunkSize:      300000,  // 300KB
 		MaxSubmissionTime: 60 * 60, // 1 hour
+
+		L2StartHeight:    0,
+		BatchStartHeight: 0,
 	}
 }
 
@@ -112,8 +124,9 @@ func (cfg Config) Validate() error {
 		return errors.New("L2 chain ID is required")
 	}
 	if cfg.DAChainID == "" {
-		return errors.New("L2 RPC URL is required")
+		return errors.New("DA chain ID is required")
 	}
+
 	if cfg.ListenAddress == "" {
 		return errors.New("listen address is required")
 	}

--- a/go.mod
+++ b/go.mod
@@ -181,4 +181,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+replace (
+	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	github.com/initia-labs/OPinit => ../opinit
+	github.com/initia-labs/OPinit/api => ../opinit/api
+)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cometbft/cometbft v0.38.10
 	github.com/cosmos/cosmos-sdk v0.50.8
 	github.com/gofiber/fiber/v2 v2.52.5
-	github.com/initia-labs/OPinit v0.4.1
+	github.com/initia-labs/OPinit v0.4.2
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -181,8 +181,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/initia-labs/OPinit => ../opinit
-	github.com/initia-labs/OPinit/api => ../opinit/api
-)
+replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -476,10 +476,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/initia-labs/OPinit v0.4.1 h1:g6IVEAOe2X31pgjk/q0zg4R1GfNj2QP3q5s3HMcWm8w=
-github.com/initia-labs/OPinit v0.4.1/go.mod h1:n0eqwOnVGE1vuTnW+3jzyEXfE4ndTM0vCRGmPu9VvUc=
-github.com/initia-labs/OPinit/api v0.4.1 h1:Q8etW92LiwekKZxzDYVFdiHF3uOpEA4nyajy8zpcxB0=
-github.com/initia-labs/OPinit/api v0.4.1/go.mod h1:Xy/Nt3ubXLQ4zKn0m7RuQOM1sj8TVdlNNyek21TGYR0=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/initia-labs/OPinit v0.4.2 h1:cfE6LXb3EquDK1/UTDT62o9c2HOQL0E9pWTr5BWAf8g=
+github.com/initia-labs/OPinit v0.4.2/go.mod h1:bM+tav+ER4uC6U84PB5vgnRUNyjc/phNgHGYQX9ALhg=
+github.com/initia-labs/OPinit/api v0.4.1 h1:Q8etW92LiwekKZxzDYVFdiHF3uOpEA4nyajy8zpcxB0=
+github.com/initia-labs/OPinit/api v0.4.1/go.mod h1:Xy/Nt3ubXLQ4zKn0m7RuQOM1sj8TVdlNNyek21TGYR0=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/keys/codec.go
+++ b/keys/codec.go
@@ -2,6 +2,8 @@ package keys
 
 import (
 	"cosmossdk.io/x/tx/signing"
+	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codecaddress "github.com/cosmos/cosmos-sdk/codec/address"
@@ -9,7 +11,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 type RegisterInterfaces func(registry codectypes.InterfaceRegistry)

--- a/keys/keyring.go
+++ b/keys/keyring.go
@@ -3,9 +3,10 @@ package keys
 import (
 	"io"
 
+	"github.com/cosmos/go-bip39"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/go-bip39"
 )
 
 func GetKeyBase(chainId string, dir string, cdc codec.Codec, userInput io.Reader) (keyring.Keyring, error) {

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -170,6 +170,11 @@ func (m *Merkle) GetWorkingTreeLeafCount() uint64 {
 	return m.workingTree.LeafCount
 }
 
+// GetStartLeafIndex returns the start leaf index of the working tree.
+func (m *Merkle) GetStartLeafIndex() uint64 {
+	return m.workingTree.StartLeafIndex
+}
+
 func (m *Merkle) saveNode(height uint8, localNodeIndex uint64, data []byte) error {
 	return m.db.Set(merkletypes.PrefixedNodeKey(m.GetWorkingTreeIndex(), height, localNodeIndex), data)
 }

--- a/node/broadcaster/broadcaster.go
+++ b/node/broadcaster/broadcaster.go
@@ -158,7 +158,9 @@ func (b *Broadcaster) prepareBroadcaster(_ /*lastBlockHeight*/ uint64, lastBlock
 
 		// if we have pending txs, wait until timeout
 		if timeoutTime := pendingTxTime.Add(b.cfg.TxTimeout); lastBlockTime.Before(timeoutTime) {
-			timer := time.NewTimer(timeoutTime.Sub(lastBlockTime))
+			waitingTime := timeoutTime.Sub(lastBlockTime)
+			timer := time.NewTimer(waitingTime)
+			b.logger.Info("waiting for pending txs to be processed", zap.Duration("waiting_time", waitingTime))
 			<-timer.C
 		}
 

--- a/node/broadcaster/broadcaster.go
+++ b/node/broadcaster/broadcaster.go
@@ -8,13 +8,14 @@ import (
 
 	rpccoretypes "github.com/cometbft/cometbft/rpc/core/types"
 
+	"github.com/pkg/errors"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	"github.com/pkg/errors"
 
 	btypes "github.com/initia-labs/opinit-bots-go/node/broadcaster/types"
 	"github.com/initia-labs/opinit-bots-go/node/rpcclient"

--- a/node/broadcaster/broadcaster.go
+++ b/node/broadcaster/broadcaster.go
@@ -134,7 +134,7 @@ func (b *Broadcaster) prepareBroadcaster(_ /*lastBlockHeight*/ uint64, lastBlock
 		WithAccountRetriever(b).
 		WithChainID(b.cfg.ChainID).
 		WithTxConfig(b.txConfig).
-		WithGasAdjustment(btypes.GAS_ADJUSTMENT).
+		WithGasAdjustment(b.cfg.GasAdjustment).
 		WithGasPrices(b.cfg.GasPrice).
 		WithKeybase(b.keyBase).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT)
@@ -156,7 +156,7 @@ func (b *Broadcaster) prepareBroadcaster(_ /*lastBlockHeight*/ uint64, lastBlock
 		pendingTxTime := time.Unix(0, loadedPendingTxs[0].Timestamp)
 
 		// if we have pending txs, wait until timeout
-		if timeoutTime := pendingTxTime.Add(btypes.TX_TIMEOUT); lastBlockTime.Before(timeoutTime) {
+		if timeoutTime := pendingTxTime.Add(b.cfg.TxTimeout); lastBlockTime.Before(timeoutTime) {
 			timer := time.NewTimer(timeoutTime.Sub(lastBlockTime))
 			<-timer.C
 		}

--- a/node/broadcaster/process.go
+++ b/node/broadcaster/process.go
@@ -85,7 +85,7 @@ func (b *Broadcaster) RemovePendingTx(blockHeight int64, txHash string, sequence
 		return err
 	}
 
-	b.logger.Debug("tx inserted", zap.Int64("height", blockHeight), zap.Uint64("sequence", sequence), zap.String("txHash", txHash))
+	b.logger.Info("tx inserted", zap.Int64("height", blockHeight), zap.Uint64("sequence", sequence), zap.String("txHash", txHash))
 	b.dequeueLocalPendingTx()
 
 	return nil

--- a/node/broadcaster/process.go
+++ b/node/broadcaster/process.go
@@ -115,6 +115,7 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 					break
 				} else if !data.Save {
 					// if the message does not need to be saved, we can skip retry
+					err = nil
 					break
 				}
 				b.logger.Warn("retry", zap.Int("count", retry), zap.String("error", err.Error()))

--- a/node/broadcaster/process.go
+++ b/node/broadcaster/process.go
@@ -112,8 +112,7 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 					err = nil
 					break
 				}
-				b.logger.Warn("retry", zap.Int("count", retry), zap.String("error", err.Error()))
-
+				b.logger.Warn("retry to handle processed msgs after 30 seconds", zap.Int("count", retry), zap.String("error", err.Error()))
 				timer := time.NewTimer(30 * time.Second)
 				select {
 				case <-ctx.Done():

--- a/node/broadcaster/process.go
+++ b/node/broadcaster/process.go
@@ -22,7 +22,7 @@ func (b Broadcaster) GetHeight() uint64 {
 func (b *Broadcaster) HandleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpccoretypes.ResultBlockResults, latestChainHeight uint64) error {
 	// check pending txs first
 	for _, tx := range block.Block.Txs {
-		if b.lenLocalPendingTx() == 0 {
+		if b.LenLocalPendingTx() == 0 {
 			break
 		}
 
@@ -37,7 +37,7 @@ func (b *Broadcaster) HandleNewBlock(block *rpccoretypes.ResultBlock, blockResul
 
 	// check timeout of pending txs
 	// @sh-cha: should we rebroadcast pending txs? or rasing monitoring alert?
-	if length := b.lenLocalPendingTx(); length > 0 {
+	if length := b.LenLocalPendingTx(); length > 0 {
 		b.logger.Debug("remaining pending txs", zap.Int64("height", block.Block.Height), zap.Int("count", length))
 		pendingTxTime := time.Unix(0, b.peekLocalPendingTx().Timestamp)
 		if block.Block.Time.After(pendingTxTime.Add(b.cfg.TxTimeout)) {
@@ -53,7 +53,7 @@ func (b *Broadcaster) HandleNewBlock(block *rpccoretypes.ResultBlock, blockResul
 
 // CheckPendingTx query tx info to check if pending tx is processed.
 func (b *Broadcaster) CheckPendingTx(ctx context.Context) (*btypes.PendingTxInfo, *rpccoretypes.ResultTx, error) {
-	if b.lenLocalPendingTx() == 0 {
+	if b.LenLocalPendingTx() == 0 {
 		return nil, nil, nil
 	}
 

--- a/node/broadcaster/tx.go
+++ b/node/broadcaster/tx.go
@@ -244,7 +244,7 @@ func (b *Broadcaster) peekLocalPendingTx() btypes.PendingTxInfo {
 	return b.pendingTxs[0]
 }
 
-func (b Broadcaster) lenLocalPendingTx() int {
+func (b Broadcaster) LenLocalPendingTx() int {
 	b.pendingTxMu.Lock()
 	defer b.pendingTxMu.Unlock()
 

--- a/node/broadcaster/tx.go
+++ b/node/broadcaster/tx.go
@@ -191,7 +191,7 @@ func (b Broadcaster) adjustEstimatedGas(gasUsed uint64) (uint64, error) {
 		return gasUsed, nil
 	}
 
-	gas := btypes.GAS_ADJUSTMENT * float64(gasUsed)
+	gas := b.cfg.GasAdjustment * float64(gasUsed)
 	if math.IsInf(gas, 1) {
 		return 0, fmt.Errorf("infinite gas used")
 	}

--- a/node/broadcaster/tx.go
+++ b/node/broadcaster/tx.go
@@ -119,6 +119,7 @@ func (b *Broadcaster) handleProcessedMsgs(ctx context.Context, data btypes.Proce
 		Tx:              txBytes,
 		TxHash:          txHash,
 		Timestamp:       data.Timestamp,
+		MsgTypes:        data.GetMsgTypes(),
 		Save:            data.Save,
 	}
 

--- a/node/broadcaster/types/config.go
+++ b/node/broadcaster/types/config.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/initia-labs/opinit-bots-go/keys"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/initia-labs/opinit-bots-go/keys"
 )
 
 type BuildTxWithMessagesFn func(context.Context, []sdk.Msg) ([]byte, string, error)

--- a/node/broadcaster/types/config.go
+++ b/node/broadcaster/types/config.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -19,6 +20,12 @@ type BroadcasterConfig struct {
 
 	// GasPrice is the gas price.
 	GasPrice string
+
+	// GasAdjustment is the gas adjustment.
+	GasAdjustment float64
+
+	// TxTimeout is the transaction timeout.
+	TxTimeout time.Duration
 
 	// Bech32Prefix is the Bech32 prefix.
 	Bech32Prefix string
@@ -61,6 +68,14 @@ func (bc BroadcasterConfig) Validate() error {
 
 	if bc.PendingTxToProcessedMsgs == nil {
 		return fmt.Errorf("pending tx to processed msgs is nil")
+	}
+
+	if bc.GasAdjustment == 0 {
+		return fmt.Errorf("gas adjustment is zero")
+	}
+
+	if bc.TxTimeout == 0 {
+		return fmt.Errorf("tx timeout is zero")
 	}
 
 	return bc.KeyringConfig.Validate()

--- a/node/broadcaster/types/consts.go
+++ b/node/broadcaster/types/consts.go
@@ -1,8 +1,0 @@
-package types
-
-import "time"
-
-const (
-	GAS_ADJUSTMENT = 1.5
-	TX_TIMEOUT     = 60 * time.Second
-)

--- a/node/db.go
+++ b/node/db.go
@@ -18,6 +18,7 @@ func (n *Node) loadSyncInfo(startHeight uint64) error {
 	data, err := n.db.Get(nodetypes.LastProcessedBlockHeightKey)
 	if err == dbtypes.ErrNotFound {
 		n.SetSyncInfo(startHeight)
+		n.startHeightInitialized = true
 		return nil
 	} else if err != nil {
 		return err

--- a/node/db.go
+++ b/node/db.go
@@ -14,9 +14,10 @@ func (n *Node) SetSyncInfo(height uint64) {
 	}
 }
 
-func (n *Node) loadSyncInfo() error {
+func (n *Node) loadSyncInfo(startHeight uint64) error {
 	data, err := n.db.Get(nodetypes.LastProcessedBlockHeightKey)
 	if err == dbtypes.ErrNotFound {
+		n.SetSyncInfo(startHeight)
 		return nil
 	} else if err != nil {
 		return err

--- a/node/node.go
+++ b/node/node.go
@@ -36,7 +36,6 @@ type Node struct {
 	rawBlockHandler   nodetypes.RawBlockHandlerFn
 
 	// status info
-	startHeightInitialized   bool
 	lastProcessedBlockHeight uint64
 	running                  bool
 }
@@ -95,10 +94,6 @@ func NewNode(cfg nodetypes.NodeConfig, db types.DB, logger *zap.Logger, cdc code
 func (n *Node) Initialize(startHeight uint64) error {
 	// load sync info
 	return n.loadSyncInfo(startHeight)
-}
-
-func (n *Node) HeightInitialized() bool {
-	return n.startHeightInitialized
 }
 
 func (n *Node) Start(ctx context.Context) {

--- a/node/node.go
+++ b/node/node.go
@@ -190,12 +190,16 @@ func (n Node) MustGetBroadcaster() *broadcaster.Broadcaster {
 }
 
 func (n Node) GetStatus() nodetypes.Status {
-	s := nodetypes.Status{
-		LastProcessedBlockHeight: n.GetHeight(),
+	s := nodetypes.Status{}
+	if n.cfg.ProcessType != nodetypes.PROCESS_TYPE_ONLY_BROADCAST {
+		s.LastProcessedBlockHeight = n.GetHeight()
 	}
+
 	if n.broadcaster != nil {
-		s.PendingTxs = n.broadcaster.LenLocalPendingTx()
-		s.Sequence = n.broadcaster.GetTxf().Sequence()
+		s.Broadcaster = nodetypes.BroadcasterStatus{
+			PendingTxs: n.broadcaster.LenLocalPendingTx(),
+			Sequence:   n.broadcaster.GetTxf().Sequence(),
+		}
 	}
 	return s
 }

--- a/node/node.go
+++ b/node/node.go
@@ -7,14 +7,15 @@ import (
 	"github.com/pkg/errors"
 
 	"cosmossdk.io/core/address"
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/initia-labs/opinit-bots-go/node/broadcaster"
 	"github.com/initia-labs/opinit-bots-go/node/rpcclient"
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
 	"github.com/initia-labs/opinit-bots-go/types"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 type Node struct {
@@ -189,17 +190,14 @@ func (n Node) MustGetBroadcaster() *broadcaster.Broadcaster {
 }
 
 func (n Node) GetStatus() nodetypes.Status {
-	pendingTxs := 0
-	sequence := uint64(0)
-	if n.broadcaster != nil {
-		pendingTxs = n.broadcaster.LenLocalPendingTx()
-		sequence = n.broadcaster.GetTxf().Sequence()
-	}
-	return nodetypes.Status{
+	s := nodetypes.Status{
 		LastProcessedBlockHeight: n.GetHeight(),
-		PendingTxs:               pendingTxs,
-		Sequence:                 sequence,
 	}
+	if n.broadcaster != nil {
+		s.PendingTxs = n.broadcaster.LenLocalPendingTx()
+		s.Sequence = n.broadcaster.GetTxf().Sequence()
+	}
+	return s
 }
 
 func (n Node) GetRPCClient() *rpcclient.RPCClient {

--- a/node/node.go
+++ b/node/node.go
@@ -188,6 +188,20 @@ func (n Node) MustGetBroadcaster() *broadcaster.Broadcaster {
 	return n.broadcaster
 }
 
+func (n Node) GetStatus() nodetypes.Status {
+	pendingTxs := 0
+	sequence := uint64(0)
+	if n.broadcaster != nil {
+		pendingTxs = n.broadcaster.LenLocalPendingTx()
+		sequence = n.broadcaster.GetTxf().Sequence()
+	}
+	return nodetypes.Status{
+		LastProcessedBlockHeight: n.GetHeight(),
+		PendingTxs:               pendingTxs,
+		Sequence:                 sequence,
+	}
+}
+
 func (n Node) GetRPCClient() *rpcclient.RPCClient {
 	return n.rpcClient
 }

--- a/node/node.go
+++ b/node/node.go
@@ -36,6 +36,7 @@ type Node struct {
 	rawBlockHandler   nodetypes.RawBlockHandlerFn
 
 	// status info
+	startHeightInitialized   bool
 	lastProcessedBlockHeight uint64
 	running                  bool
 }
@@ -94,6 +95,10 @@ func NewNode(cfg nodetypes.NodeConfig, db types.DB, logger *zap.Logger, cdc code
 func (n *Node) Initialize(startHeight uint64) error {
 	// load sync info
 	return n.loadSyncInfo(startHeight)
+}
+
+func (n *Node) HeightInitialized() bool {
+	return n.startHeightInitialized
 }
 
 func (n *Node) Start(ctx context.Context) {

--- a/node/process.go
+++ b/node/process.go
@@ -227,13 +227,13 @@ func (n *Node) txChecker(ctx context.Context) error {
 
 				err := n.handleEvent(ctx, uint64(res.Height), 0, event)
 				if err != nil {
-					n.logger.Error("failed to handle event", zap.String("txHash", pendingTx.TxHash), zap.Int("event_index", eventIndex), zap.String("error", err.Error()))
+					n.logger.Error("failed to handle event", zap.String("tx_hash", pendingTx.TxHash), zap.Int("event_index", eventIndex), zap.String("error", err.Error()))
 					break
 				}
 			}
 		}
 
-		err = n.broadcaster.RemovePendingTx(res.Height, pendingTx.TxHash, pendingTx.Sequence)
+		err = n.broadcaster.RemovePendingTx(res.Height, pendingTx.TxHash, pendingTx.Sequence, pendingTx.MsgTypes)
 		if err != nil {
 			return err
 		}

--- a/node/process.go
+++ b/node/process.go
@@ -8,12 +8,13 @@ import (
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	rpccoretypes "github.com/cometbft/cometbft/rpc/core/types"
 	nodetypes "github.com/initia-labs/opinit-bots-go/node/types"
+	"github.com/initia-labs/opinit-bots-go/types"
 	"go.uber.org/zap"
 )
 
 // blockProcessLooper fetches new blocks and processes them
 func (n *Node) blockProcessLooper(ctx context.Context, processType nodetypes.BlockProcessType) error {
-	timer := time.NewTicker(nodetypes.POLLING_INTERVAL)
+	timer := time.NewTicker(types.PollingInterval(ctx))
 	defer timer.Stop()
 
 	for {
@@ -40,7 +41,7 @@ func (n *Node) blockProcessLooper(ctx context.Context, processType nodetypes.Blo
 				select {
 				case <-ctx.Done():
 					return nil
-				default:
+				case <-timer.C:
 				}
 				// TODO: may fetch blocks in batch
 				block, blockResult, err := n.fetchNewBlock(ctx, int64(queryHeight))
@@ -50,7 +51,7 @@ func (n *Node) blockProcessLooper(ctx context.Context, processType nodetypes.Blo
 					break
 				}
 
-				err = n.handleNewBlock(block, blockResult, latestChainHeight)
+				err = n.handleNewBlock(ctx, block, blockResult, latestChainHeight)
 				if err != nil {
 					// TODO: handle error
 					n.logger.Error("failed to handle new block", zap.String("error", err.Error()))
@@ -67,7 +68,7 @@ func (n *Node) blockProcessLooper(ctx context.Context, processType nodetypes.Blo
 				end = latestChainHeight
 			}
 
-			blockBulk, err := n.rpcClient.QueryBlockBulk(start, end)
+			blockBulk, err := n.rpcClient.QueryBlockBulk(ctx, start, end)
 			if err != nil {
 				n.logger.Error("failed to fetch block bulk", zap.String("error", err.Error()))
 				continue
@@ -79,7 +80,7 @@ func (n *Node) blockProcessLooper(ctx context.Context, processType nodetypes.Blo
 					return nil
 				default:
 				}
-				err := n.rawBlockHandler(nodetypes.RawBlockArgs{
+				err := n.rawBlockHandler(ctx, nodetypes.RawBlockArgs{
 					BlockHeight: i,
 					BlockBytes:  blockBulk[i-start],
 				})
@@ -110,7 +111,7 @@ func (n *Node) fetchNewBlock(ctx context.Context, height int64) (block *rpccoret
 	return block, blockResult, nil
 }
 
-func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpccoretypes.ResultBlockResults, latestChainHeight uint64) error {
+func (n *Node) handleNewBlock(ctx context.Context, block *rpccoretypes.ResultBlock, blockResult *rpccoretypes.ResultBlockResults, latestChainHeight uint64) error {
 	protoBlock, err := block.Block.ToProto()
 	if err != nil {
 		return err
@@ -125,7 +126,7 @@ func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpcc
 	}
 
 	if n.beginBlockHandler != nil {
-		err := n.beginBlockHandler(nodetypes.BeginBlockArgs{
+		err := n.beginBlockHandler(ctx, nodetypes.BeginBlockArgs{
 			BlockID:      block.BlockID.Hash,
 			Block:        *protoBlock,
 			LatestHeight: latestChainHeight,
@@ -137,7 +138,7 @@ func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpcc
 
 	for txIndex, tx := range block.Block.Txs {
 		if n.txHandler != nil {
-			err := n.txHandler(nodetypes.TxHandlerArgs{
+			err := n.txHandler(ctx, nodetypes.TxHandlerArgs{
 				BlockHeight:  uint64(block.Block.Height),
 				LatestHeight: latestChainHeight,
 				TxIndex:      uint64(txIndex),
@@ -151,7 +152,7 @@ func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpcc
 		if len(n.eventHandlers) != 0 {
 			events := blockResult.TxsResults[txIndex].GetEvents()
 			for eventIndex, event := range events {
-				err := n.handleEvent(uint64(block.Block.Height), latestChainHeight, event)
+				err := n.handleEvent(ctx, uint64(block.Block.Height), latestChainHeight, event)
 				if err != nil {
 					return fmt.Errorf("failed to handle event: tx_index: %d, event_index: %d; %w", txIndex, eventIndex, err)
 				}
@@ -160,14 +161,14 @@ func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpcc
 	}
 
 	for eventIndex, event := range blockResult.FinalizeBlockEvents {
-		err := n.handleEvent(uint64(block.Block.Height), latestChainHeight, event)
+		err := n.handleEvent(ctx, uint64(block.Block.Height), latestChainHeight, event)
 		if err != nil {
 			return fmt.Errorf("failed to handle event: finalize block, event_index: %d; %w", eventIndex, err)
 		}
 	}
 
 	if n.endBlockHandler != nil {
-		err := n.endBlockHandler(nodetypes.EndBlockArgs{
+		err := n.endBlockHandler(ctx, nodetypes.EndBlockArgs{
 			BlockID:      block.BlockID.Hash,
 			Block:        *protoBlock,
 			LatestHeight: latestChainHeight,
@@ -179,13 +180,13 @@ func (n *Node) handleNewBlock(block *rpccoretypes.ResultBlock, blockResult *rpcc
 	return nil
 }
 
-func (n *Node) handleEvent(blockHeight uint64, latestHeight uint64, event abcitypes.Event) error {
+func (n *Node) handleEvent(ctx context.Context, blockHeight uint64, latestHeight uint64, event abcitypes.Event) error {
 	if n.eventHandlers[event.GetType()] == nil {
 		return nil
 	}
 
 	n.logger.Debug("handle event", zap.Uint64("height", blockHeight), zap.String("type", event.GetType()))
-	return n.eventHandlers[event.Type](nodetypes.EventHandlerArgs{
+	return n.eventHandlers[event.Type](ctx, nodetypes.EventHandlerArgs{
 		BlockHeight:     blockHeight,
 		LatestHeight:    latestHeight,
 		EventAttributes: event.GetAttributes(),
@@ -198,7 +199,7 @@ func (n *Node) txChecker(ctx context.Context) error {
 		return nil
 	}
 
-	timer := time.NewTicker(nodetypes.POLLING_INTERVAL)
+	timer := time.NewTicker(types.PollingInterval(ctx))
 	defer timer.Stop()
 	for {
 		select {
@@ -207,7 +208,7 @@ func (n *Node) txChecker(ctx context.Context) error {
 		case <-timer.C:
 		}
 
-		pendingTx, res, err := n.broadcaster.CheckPendingTx()
+		pendingTx, res, err := n.broadcaster.CheckPendingTx(ctx)
 		if err != nil {
 			return err
 		} else if pendingTx == nil || res == nil {
@@ -224,7 +225,7 @@ func (n *Node) txChecker(ctx context.Context) error {
 				default:
 				}
 
-				err := n.handleEvent(uint64(res.Height), 0, event)
+				err := n.handleEvent(ctx, uint64(res.Height), 0, event)
 				if err != nil {
 					n.logger.Error("failed to handle event", zap.String("txHash", pendingTx.TxHash), zap.Int("event_index", eventIndex), zap.String("error", err.Error()))
 					break

--- a/node/rpcclient/client.go
+++ b/node/rpcclient/client.go
@@ -167,10 +167,10 @@ func GetHeightFromMetadata(md metadata.MD) (int64, error) {
 
 // Canceling this context releases resources associated with it, so code should
 // call cancel as soon as the operations running in this [Context] complete:
-func GetQueryContext(height uint64) (context.Context, context.CancelFunc) {
+func GetQueryContext(ctx context.Context, height uint64) (context.Context, context.CancelFunc) {
 	// TODO: configurable timeout
 	timeout := 10 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 
 	strHeight := strconv.FormatUint(height, 10)
 	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
@@ -178,21 +178,21 @@ func GetQueryContext(height uint64) (context.Context, context.CancelFunc) {
 }
 
 // QueryRawCommit queries the raw commit at a given height.
-func (q RPCClient) QueryRawCommit(height int64) ([]byte, error) {
-	ctx, cancel := GetQueryContext(uint64(height))
+func (q RPCClient) QueryRawCommit(ctx context.Context, height int64) ([]byte, error) {
+	ctx, cancel := GetQueryContext(ctx, uint64(height))
 	defer cancel()
 	return q.RawCommit(ctx, &height)
 }
 
 // QueryBlockBulk queries blocks in bulk.
-func (q RPCClient) QueryBlockBulk(start uint64, end uint64) ([][]byte, error) {
-	ctx, cancel := GetQueryContext(0)
+func (q RPCClient) QueryBlockBulk(ctx context.Context, start uint64, end uint64) ([][]byte, error) {
+	ctx, cancel := GetQueryContext(ctx, 0)
 	defer cancel()
 	return q.BlockBulk(ctx, &start, &end)
 }
 
-func (q RPCClient) QueryTx(txHash []byte) (*coretypes.ResultTx, error) {
-	ctx, cancel := GetQueryContext(0)
+func (q RPCClient) QueryTx(ctx context.Context, txHash []byte) (*coretypes.ResultTx, error) {
+	ctx, cancel := GetQueryContext(ctx, 0)
 	defer cancel()
 	return q.Tx(ctx, txHash, false)
 }

--- a/node/rpcclient/client.go
+++ b/node/rpcclient/client.go
@@ -17,11 +17,12 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	client2 "github.com/cometbft/cometbft/rpc/client"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	legacyerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
-	gogogrpc "github.com/cosmos/gogoproto/grpc"
 
 	clienthttp "github.com/initia-labs/opinit-bots-go/client"
 )

--- a/node/types/const.go
+++ b/node/types/const.go
@@ -1,7 +1,0 @@
-package types
-
-import (
-	"time"
-)
-
-const POLLING_INTERVAL = 1 * time.Second

--- a/node/types/handler.go
+++ b/node/types/handler.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"context"
+
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	comettypes "github.com/cometbft/cometbft/types"
@@ -13,7 +15,7 @@ type EventHandlerArgs struct {
 	EventAttributes []abcitypes.EventAttribute
 }
 
-type EventHandlerFn func(EventHandlerArgs) error
+type EventHandlerFn func(context.Context, EventHandlerArgs) error
 
 type TxHandlerArgs struct {
 	BlockHeight  uint64
@@ -22,7 +24,7 @@ type TxHandlerArgs struct {
 	Tx           comettypes.Tx
 }
 
-type TxHandlerFn func(TxHandlerArgs) error
+type TxHandlerFn func(context.Context, TxHandlerArgs) error
 
 type BeginBlockArgs struct {
 	BlockID      []byte
@@ -30,7 +32,7 @@ type BeginBlockArgs struct {
 	LatestHeight uint64
 }
 
-type BeginBlockHandlerFn func(BeginBlockArgs) error
+type BeginBlockHandlerFn func(context.Context, BeginBlockArgs) error
 
 type EndBlockArgs struct {
 	BlockID      []byte
@@ -38,11 +40,11 @@ type EndBlockArgs struct {
 	LatestHeight uint64
 }
 
-type EndBlockHandlerFn func(EndBlockArgs) error
+type EndBlockHandlerFn func(context.Context, EndBlockArgs) error
 
 type RawBlockArgs struct {
 	BlockHeight uint64
 	BlockBytes  []byte
 }
 
-type RawBlockHandlerFn func(RawBlockArgs) error
+type RawBlockHandlerFn func(context.Context, RawBlockArgs) error

--- a/node/types/status.go
+++ b/node/types/status.go
@@ -2,6 +2,6 @@ package types
 
 type Status struct {
 	LastProcessedBlockHeight uint64 `json:"last_processed_block_height"`
-	PendingTxs               int    `json:"pending_txs"`
-	Sequence                 uint64 `json:"sequence"`
+	PendingTxs               int    `json:"pending_txs,omitempty"`
+	Sequence                 uint64 `json:"sequence,omitempty"`
 }

--- a/node/types/status.go
+++ b/node/types/status.go
@@ -1,7 +1,11 @@
 package types
 
+type BroadcasterStatus struct {
+	PendingTxs int    `json:"pending_txs"`
+	Sequence   uint64 `json:"sequence"`
+}
+
 type Status struct {
-	LastProcessedBlockHeight uint64 `json:"last_processed_block_height"`
-	PendingTxs               int    `json:"pending_txs,omitempty"`
-	Sequence                 uint64 `json:"sequence,omitempty"`
+	LastProcessedBlockHeight uint64            `json:"last_processed_block_height,omitempty"`
+	Broadcaster              BroadcasterStatus `json:"broadcaster,omitempty"`
 }

--- a/node/types/status.go
+++ b/node/types/status.go
@@ -1,0 +1,7 @@
+package types
+
+type Status struct {
+	LastProcessedBlockHeight uint64 `json:"last_processed_block_height"`
+	PendingTxs               int    `json:"pending_txs"`
+	Sequence                 uint64 `json:"sequence"`
+}

--- a/types/const.go
+++ b/types/const.go
@@ -1,7 +1,0 @@
-package types
-
-type contextKey string
-
-var (
-	ContextKeyErrGrp = contextKey("ErrGrp")
-)

--- a/types/context.go
+++ b/types/context.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type contextKey string
+
+var (
+	ContextKeyErrGrp          = contextKey("ErrGrp")
+	ContextKeyPollingInterval = contextKey("PollingInterval")
+	ContextKeyTxTimeout       = contextKey("TxTimeout")
+)
+
+func WithErrGrp(ctx context.Context, errGrp *errgroup.Group) context.Context {
+	return context.WithValue(ctx, ContextKeyErrGrp, errGrp)
+}
+
+func ErrGrp(ctx context.Context) *errgroup.Group {
+	return ctx.Value(ContextKeyErrGrp).(*errgroup.Group)
+}
+
+func WithPollingInterval(ctx context.Context, interval time.Duration) context.Context {
+	return context.WithValue(ctx, ContextKeyPollingInterval, interval)
+}
+
+func PollingInterval(ctx context.Context) time.Duration {
+	interval := ctx.Value(ContextKeyPollingInterval)
+	if interval == nil {
+		return 100 * time.Millisecond
+	}
+	return ctx.Value(ContextKeyPollingInterval).(time.Duration)
+}


### PR DESCRIPTION
Added a config to start from a specific height. If you enter l2 height, it starts from the l2 block number +1 of the last output smaller than that.

A batch can also start from a specific height or from an initialized l2 height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced context-aware method signatures across various components, enabling better management of cancellations and timeouts.
  - Added a command in the documentation for querying the status of the bot via `curl`.

- **Bug Fixes**
  - Improved error handling mechanisms to enhance the reliability of transaction processing.

- **Documentation**
  - Enhanced clarity in documentation regarding new configuration options for transaction management.

- **Refactor**
  - Streamlined method signatures and control flows across the Node, Broadcaster, and Executor components for better readability and maintainability.

- **Chores**
  - Updated the version of the `github.com/initia-labs/OPinit` dependency from `v0.4.1` to `v0.4.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->