### PR TITLE
fix: the path of binaries in tarball

### DIFF
--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -33,8 +33,9 @@ jobs:
           GOARCH=amd64 make build
           mv ./build/opinitd ./build/opinitd.amd64
           lipo -create -output ./build/opinitd  ./build/opinitd.arm64 ./build/opinitd.amd64
-          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Darwin.tar.gz ./build/opinitd
-          rm ./build/opinitd.arm64 ./build/opinitd.amd64 ./build/opinitd
+          pushd build
+          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Darwin.tar.gz ./opinitd
+          rm ./opinitd.arm64 ./opinitd.amd64 ./opinitd; popd
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,11 +29,13 @@ jobs:
       - name: Build and Package for Linux
         run: |
           make build
-          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Linux_x86_64.tar.gz ./build/opinitd
-          rm build/opinitd
+          pushd build
+          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Linux_x86_64.tar.gz ./opinitd
+          rm ./opinitd; popd
           GOARCH=arm64 make build
-          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Linux_aarch64.tar.gz ./build/opinitd
-          rm build/opinitd
+          pushd build
+          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Linux_aarch64.tar.gz ./opinitd
+          rm ./opinitd; popd
 
       - name: Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
there's relative path path `./build` in the tarball :sob:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the build and packaging process for Darwin and Linux executables.
	- Enhanced directory management during packaging to improve clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->