### PR TITLE
split universal macos binary into two

### DIFF
--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -29,18 +29,19 @@ jobs:
       - name: Build and Package for Darwin
         run: |
           make build
-          mv ./build/opinitd ./build/opinitd.arm64
-          GOARCH=amd64 make build
-          mv ./build/opinitd ./build/opinitd.amd64
-          lipo -create -output ./build/opinitd  ./build/opinitd.arm64 ./build/opinitd.amd64
           pushd build
-          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Darwin.tar.gz ./opinitd
-          rm ./opinitd.arm64 ./opinitd.amd64 ./opinitd; popd
+          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Darwin_aarch64.tar.gz ./opinitd
+          rm ./opinitd; popd
+          GOARCH=amd64 make build
+          pushd build
+          tar -czf "$GITHUB_WORKSPACE"/opinitd_"$VERSION"_Darwin_x86_64.tar.gz ./opinitd
+          rm ./opinitd; popd
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            opinitd_${{ env.VERSION }}_Darwin.tar.gz
+            opinitd_${{ env.VERSION }}_Darwin_x86_64.tar.gz
+            opinitd_${{ env.VERSION }}_Darwin_aarch64.tar.gz
         env:
           VERSION: ${{ env.VERSION }}


### PR DESCRIPTION
to sync `initiad` and `minitiad`s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced separate packaging for ARM64 and AMD64 architectures for Darwin executable binaries.
	- Updated naming conventions for packaged binaries to reflect architecture specifics.

- **Bug Fixes**
	- Streamlined the build process by eliminating the combined binary, ensuring distinct packages for each architecture.

- **Documentation**
	- Updated the release step to include both ARM64 and AMD64 tarballs for clarity in distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->