### PR TITLE
fix: handle events only when event handlers are registered

### DIFF
--- a/node/process.go
+++ b/node/process.go
@@ -170,10 +170,12 @@ func (n *Node) handleNewBlock(ctx context.Context, block *rpccoretypes.ResultBlo
 		}
 	}
 
-	for eventIndex, event := range blockResult.FinalizeBlockEvents {
-		err := n.handleEvent(ctx, block.Block.Height, block.Block.Time, latestChainHeight, event)
-		if err != nil {
-			return fmt.Errorf("failed to handle event: finalize block, event_index: %d; %w", eventIndex, err)
+	if len(n.eventHandlers) != 0 {
+		for eventIndex, event := range blockResult.FinalizeBlockEvents {
+			err := n.handleEvent(ctx, block.Block.Height, block.Block.Time, latestChainHeight, event)
+			if err != nil {
+				return fmt.Errorf("failed to handle event: finalize block, event_index: %d; %w", eventIndex, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Inside `Node.handleNewBlock`, `blockResult` can be `nil` if `n.eventHandlers` was empty. But the current code always iterates over `blockResult.FinalizeBlockEvents` which causes a panic when we run `Node` without any event handlers. This PR fixes this bug by checking if `n.eventHandlers` is empty or not before the iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced efficiency in event handling for finalize block events by checking for registered handlers before processing.
	- Maintained existing functionality for block processing while optimizing the event handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->