### PR TITLE
add l1 start height in config to avoid to use TxSearch

### DIFF
--- a/challenger/README.md
+++ b/challenger/README.md
@@ -10,7 +10,7 @@ The Challenger is responsible for
 
 ## Config
 
-To configure the Executor, fill in the values in the `~/.opinit/executor.json` file.
+To configure the Challenger, fill in the values in the `~/.opinit/challenger.json` file.
 
 ```json
 {
@@ -28,6 +28,11 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
     "bech32_prefix": "init",
     "rpc_address": "tcp://localhost:27657",
   },
+  // L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
+	// However, if you do not want to use this feature, set it to a non-zero value.
+	// There is no need for modification under normal circumstances, because it
+	// is automatically determined when you set the l2 start height,
+	"l1_start_height": 0,
   // L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
   // L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.

--- a/challenger/README.md
+++ b/challenger/README.md
@@ -29,10 +29,10 @@ To configure the Challenger, fill in the values in the `~/.opinit/challenger.jso
     "rpc_address": "tcp://localhost:27657",
   },
   // L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
-	// However, if you do not want to use this feature, set it to a non-zero value.
-	// There is no need for modification under normal circumstances, because it
-	// is automatically determined when you set the l2 start height,
-	"l1_start_height": 0,
+  // However, if you do not want to use this feature, set it to a non-zero value.
+  // There is no need for modification under normal circumstances, because it
+  // is automatically determined when you set the l2 start height,
+  "l1_start_height": 0,
   // L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
   // L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.

--- a/challenger/types/config.go
+++ b/challenger/types/config.go
@@ -37,11 +37,16 @@ type Config struct {
 	// L2Node is the configuration for the l2 node.
 	L2Node NodeConfig `json:"l2_node"`
 
+	// L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
+	// However, if you do not want to use this feature, set it to a non-zero value.
+	// There is no need for modification under normal circumstances, because it
+	// is automatically determined when you set the l2 start height,
+	L1StartHeight int64 `json:"l1_start_height"`
 	// L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
 	// If the latest height stored in the db is not 0, this config is ignored.
 	// L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
 	// L1 starts from the block number of the output tx + 1
-	L2StartHeight uint64 `json:"l2_start_height"`
+	L2StartHeight int64 `json:"l2_start_height"`
 }
 
 func DefaultConfig() *Config {
@@ -60,6 +65,7 @@ func DefaultConfig() *Config {
 			Bech32Prefix: "init",
 			RPCAddress:   "tcp://localhost:27657",
 		},
+		L1StartHeight: 0,
 		L2StartHeight: 0,
 	}
 }
@@ -83,6 +89,14 @@ func (cfg Config) Validate() error {
 
 	if err := cfg.L2Node.Validate(); err != nil {
 		return err
+	}
+
+	if cfg.L1StartHeight < 0 {
+		return errors.New("l1 start height must be greater than or equal to 0")
+	}
+
+	if cfg.L2StartHeight < 0 {
+		return errors.New("l2 start height must be greater than or equal to 0")
 	}
 	return nil
 }

--- a/executor/README.md
+++ b/executor/README.md
@@ -59,10 +59,10 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   // MaxSubmissionTime is the maximum time to submit a batch.
   "max_submission_time": 3600,
   // L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
-	// However, if you do not want to use this feature, set it to a non-zero value.
-	// There is no need for modification under normal circumstances, because it
-	// is automatically determined when you set the l2 start height,
-	"l1_start_height": 0,
+  // However, if you do not want to use this feature, set it to a non-zero value.
+  // There is no need for modification under normal circumstances, because it
+  // is automatically determined when you set the l2 start height,
+  "l1_start_height": 0,
   // L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
   // L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.

--- a/executor/README.md
+++ b/executor/README.md
@@ -58,6 +58,11 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   "max_chunk_size": 300000,
   // MaxSubmissionTime is the maximum time to submit a batch.
   "max_submission_time": 3600,
+  // L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
+	// However, if you do not want to use this feature, set it to a non-zero value.
+	// There is no need for modification under normal circumstances, because it
+	// is automatically determined when you set the l2 start height,
+	"l1_start_height": 0,
   // L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
   // L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.

--- a/executor/batch/noop_da.go
+++ b/executor/batch/noop_da.go
@@ -3,11 +3,12 @@ package batch
 import (
 	"context"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	executortypes "github.com/initia-labs/opinit-bots/executor/types"
 	btypes "github.com/initia-labs/opinit-bots/node/broadcaster/types"
 	nodetypes "github.com/initia-labs/opinit-bots/node/types"
 	"github.com/initia-labs/opinit-bots/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ executortypes.DANode = &NoopDA{}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -214,46 +214,52 @@ func (ex *Executor) makeDANode(ctx context.Context, bridgeInfo opchildtypes.Brid
 }
 
 func (ex *Executor) getProcessedHeights(ctx context.Context, bridgeId uint64) (l1ProcessedHeight int64, l2ProcessedHeight int64, processedOutputIndex uint64, batchProcessedHeight int64, err error) {
-	// get the bridge start height from the host
-	l1ProcessedHeight, err = ex.host.QueryCreateBridgeHeight(ctx, bridgeId)
-	if err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	l1Sequence, err := ex.child.QueryNextL1Sequence(ctx, 0)
-	if err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	// query l1Sequence tx height
-	depositTxHeight, err := ex.host.QueryDepositTxHeight(ctx, bridgeId, l1Sequence)
-	if err != nil {
-		return 0, 0, 0, 0, err
-	} else if depositTxHeight == 0 && l1Sequence > 1 {
-		// query l1Sequence - 1 tx height
-		depositTxHeight, err = ex.host.QueryDepositTxHeight(ctx, bridgeId, l1Sequence-1)
-		if err != nil {
-			return 0, 0, 0, 0, err
-		}
-	}
-	if depositTxHeight >= 1 && depositTxHeight-1 > l1ProcessedHeight {
-		l1ProcessedHeight = depositTxHeight - 1
-	}
-
+	var outputL1BlockNumber int64
 	// get the last submitted output height before the start height from the host
 	if ex.cfg.L2StartHeight != 0 {
 		output, err := ex.host.QueryOutputByL2BlockNumber(ctx, bridgeId, ex.cfg.L2StartHeight)
 		if err != nil {
 			return 0, 0, 0, 0, err
 		} else if output != nil {
-			l1BlockNumber := types.MustUint64ToInt64(output.OutputProposal.L1BlockNumber)
-			if l1BlockNumber < l1ProcessedHeight {
-				l1ProcessedHeight = l1BlockNumber
-			}
+			outputL1BlockNumber = types.MustUint64ToInt64(output.OutputProposal.L1BlockNumber)
 			l2ProcessedHeight = types.MustUint64ToInt64(output.OutputProposal.L2BlockNumber)
 			processedOutputIndex = output.OutputIndex
 		}
 	}
+
+	if ex.cfg.L1StartHeight == 0 {
+		// get the bridge start height from the host
+		l1ProcessedHeight, err = ex.host.QueryCreateBridgeHeight(ctx, bridgeId)
+		if err != nil {
+			return 0, 0, 0, 0, err
+		}
+
+		l1Sequence, err := ex.child.QueryNextL1Sequence(ctx, 0)
+		if err != nil {
+			return 0, 0, 0, 0, err
+		}
+
+		// query l1Sequence tx height
+		depositTxHeight, err := ex.host.QueryDepositTxHeight(ctx, bridgeId, l1Sequence)
+		if err != nil {
+			return 0, 0, 0, 0, err
+		} else if depositTxHeight == 0 && l1Sequence > 1 {
+			// query l1Sequence - 1 tx height
+			depositTxHeight, err = ex.host.QueryDepositTxHeight(ctx, bridgeId, l1Sequence-1)
+			if err != nil {
+				return 0, 0, 0, 0, err
+			}
+		}
+		if depositTxHeight > l1ProcessedHeight {
+			l1ProcessedHeight = depositTxHeight
+		}
+		if outputL1BlockNumber < l1ProcessedHeight {
+			l1ProcessedHeight = outputL1BlockNumber
+		}
+	} else {
+		l1ProcessedHeight = ex.cfg.L1StartHeight
+	}
+	l1ProcessedHeight--
 
 	if ex.cfg.BatchStartHeight > 0 {
 		batchProcessedHeight = ex.cfg.BatchStartHeight - 1

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	// MaxSubmissionTime is the maximum time to submit a batch.
 	MaxSubmissionTime int64 `json:"max_submission_time"` // seconds
 
+	// L1StartHeight is the height to start the l1 node. If it is 0, it will finds the optimal height and sets it automatically.
+	// However, if you do not want to use this feature, set it to a non-zero value.
+	// There is no need for modification under normal circumstances, because it
+	// is automatically determined when you set the l2 start height,
+	L1StartHeight int64 `json:"l1_start_height"`
 	// L2StartHeight is the height to start the l2 node. If it is 0, it will start from the latest height.
 	// If the latest height stored in the db is not 0, this config is ignored.
 	// L2 starts from the last submitted output l2 block number + 1 before L2StartHeight.
@@ -117,6 +122,7 @@ func DefaultConfig() *Config {
 		MaxChunkSize:      300000,  // 300KB
 		MaxSubmissionTime: 60 * 60, // 1 hour
 
+		L1StartHeight:    0,
 		L2StartHeight:    0,
 		BatchStartHeight: 0,
 	}
@@ -157,6 +163,10 @@ func (cfg Config) Validate() error {
 
 	if cfg.MaxSubmissionTime <= 0 {
 		return errors.New("max submission time must be greater than 0")
+	}
+
+	if cfg.L1StartHeight < 0 {
+		return errors.New("l1 start height must be greater than or equal to 0")
 	}
 
 	if cfg.L2StartHeight < 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter `l1_start_height` for both Challenger and Executor components, allowing users to specify the L1 node starting height.
	- Enhanced documentation for Challenger and Executor, providing clearer guidance on the new configuration options and their implications.

- **Bug Fixes**
	- Improved logic for calculating processed heights in both Challenger and Executor, ensuring more accurate results based on new conditions.

- **Documentation**
	- Updated README files to reflect changes in configuration details and to enhance clarity regarding the Challenger's and Executor's functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->