### PR TITLE
Feat/fetch output submitter info

### DIFF
--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -82,12 +82,17 @@ func NewChallenger(cfg *challengertypes.Config, db types.DB, sv *server.Server, 
 }
 
 func (c *Challenger) Initialize(ctx context.Context) error {
-	bridgeInfo, err := c.child.QueryBridgeInfo(ctx)
+	childBridgeInfo, err := c.child.QueryBridgeInfo(ctx)
 	if err != nil {
 		return err
 	}
-	if bridgeInfo.BridgeId == 0 {
+	if childBridgeInfo.BridgeId == 0 {
 		return errors.New("bridge info is not set")
+	}
+
+	bridgeInfo, err := c.host.QueryBridgeConfig(ctx, childBridgeInfo.BridgeId)
+	if err != nil {
+		return err
 	}
 
 	c.logger.Info(
@@ -101,11 +106,11 @@ func (c *Challenger) Initialize(ctx context.Context) error {
 		return err
 	}
 
-	err = c.host.Initialize(ctx, hostProcessedHeight, c.child, bridgeInfo, c)
+	err = c.host.Initialize(ctx, hostProcessedHeight, c.child, *bridgeInfo, c)
 	if err != nil {
 		return err
 	}
-	err = c.child.Initialize(ctx, childProcessedHeight, processedOutputIndex+1, c.host, bridgeInfo, c)
+	err = c.child.Initialize(ctx, childProcessedHeight, processedOutputIndex+1, c.host, *bridgeInfo, c)
 	if err != nil {
 		return err
 	}

--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -56,12 +56,12 @@ func NewChallenger(cfg *challengertypes.Config, db types.DB, sv *server.Server, 
 		host: host.NewHostV1(
 			cfg.L1NodeConfig(homePath),
 			db.WithPrefix([]byte(types.HostName)),
-			logger.Named(types.HostName), cfg.L1Node.Bech32Prefix,
+			logger.Named(types.HostName),
 		),
 		child: child.NewChildV1(
 			cfg.L2NodeConfig(homePath),
 			db.WithPrefix([]byte(types.ChildName)),
-			logger.Named(types.ChildName), cfg.L2Node.Bech32Prefix,
+			logger.Named(types.ChildName),
 		),
 
 		cfg:    cfg,

--- a/challenger/child/child.go
+++ b/challenger/child/child.go
@@ -56,7 +56,7 @@ func NewChildV1(
 	}
 }
 
-func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo, challenger challenger) error {
+func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse, challenger challenger) error {
 	_, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo)
 	if err != nil {
 		return err

--- a/challenger/child/child.go
+++ b/challenger/child/child.go
@@ -47,17 +47,17 @@ type Child struct {
 
 func NewChildV1(
 	cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix string,
+	db types.DB, logger *zap.Logger,
 ) *Child {
 	return &Child{
-		BaseChild:    childprovider.NewBaseChildV1(cfg, db, logger, bech32Prefix),
+		BaseChild:    childprovider.NewBaseChildV1(cfg, db, logger),
 		eventHandler: eventhandler.NewChallengeEventHandler(db, logger),
 		eventQueue:   make([]challengertypes.ChallengeEvent, 0),
 	}
 }
 
 func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse, challenger challenger) error {
-	_, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo)
+	_, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo, nil)
 	if err != nil {
 		return err
 	}

--- a/challenger/host/host.go
+++ b/challenger/host/host.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 
-	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
 
 	nodetypes "github.com/initia-labs/opinit-bots/node/types"
@@ -55,7 +54,7 @@ func NewHostV1(
 	}
 }
 
-func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, bridgeInfo opchildtypes.BridgeInfo, challenger challenger) error {
+func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, bridgeInfo ophosttypes.QueryBridgeResponse, challenger challenger) error {
 	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo)
 	if err != nil {
 		return err

--- a/challenger/host/host.go
+++ b/challenger/host/host.go
@@ -44,10 +44,10 @@ type Host struct {
 
 func NewHostV1(
 	cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix string,
+	db types.DB, logger *zap.Logger,
 ) *Host {
 	return &Host{
-		BaseHost:                hostprovider.NewBaseHostV1(cfg, db, logger, bech32Prefix),
+		BaseHost:                hostprovider.NewBaseHostV1(cfg, db, logger),
 		eventHandler:            eventhandler.NewChallengeEventHandler(db, logger),
 		eventQueue:              make([]challengertypes.ChallengeEvent, 0),
 		outputPendingEventQueue: make([]challengertypes.ChallengeEvent, 0),
@@ -55,7 +55,7 @@ func NewHostV1(
 }
 
 func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, bridgeInfo ophosttypes.QueryBridgeResponse, challenger challenger) error {
-	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo)
+	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo, nil)
 	if err != nil {
 		return err
 	}

--- a/challenger/types/config.go
+++ b/challenger/types/config.go
@@ -106,16 +106,18 @@ func (cfg Config) Validate() error {
 
 func (cfg Config) L1NodeConfig(homePath string) nodetypes.NodeConfig {
 	nc := nodetypes.NodeConfig{
-		RPC:         cfg.L1Node.RPCAddress,
-		ProcessType: nodetypes.PROCESS_TYPE_DEFAULT,
+		RPC:          cfg.L1Node.RPCAddress,
+		ProcessType:  nodetypes.PROCESS_TYPE_DEFAULT,
+		Bech32Prefix: cfg.L1Node.Bech32Prefix,
 	}
 	return nc
 }
 
 func (cfg Config) L2NodeConfig(homePath string) nodetypes.NodeConfig {
 	nc := nodetypes.NodeConfig{
-		RPC:         cfg.L2Node.RPCAddress,
-		ProcessType: nodetypes.PROCESS_TYPE_DEFAULT,
+		RPC:          cfg.L2Node.RPCAddress,
+		ProcessType:  nodetypes.PROCESS_TYPE_DEFAULT,
+		Bech32Prefix: cfg.L2Node.Bech32Prefix,
 	}
 	return nc
 }

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -31,7 +31,7 @@ type BatchSubmitter struct {
 	host hostNode
 	da   executortypes.DANode
 
-	bridgeInfo opchildtypes.BridgeInfo
+	bridgeInfo ophosttypes.QueryBridgeResponse
 
 	cfg      nodetypes.NodeConfig
 	batchCfg executortypes.BatchConfig
@@ -96,7 +96,7 @@ func NewBatchSubmitterV1(
 	return ch
 }
 
-func (bs *BatchSubmitter) Initialize(ctx context.Context, processedHeight int64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (bs *BatchSubmitter) Initialize(ctx context.Context, processedHeight int64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	err := bs.node.Initialize(ctx, processedHeight)
 	if err != nil {
 		return err
@@ -172,7 +172,7 @@ func (bs *BatchSubmitter) Close() {
 	}
 }
 
-func (bs *BatchSubmitter) SetBridgeInfo(bridgeInfo opchildtypes.BridgeInfo) {
+func (bs *BatchSubmitter) SetBridgeInfo(bridgeInfo ophosttypes.QueryBridgeResponse) {
 	bs.bridgeInfo = bridgeInfo
 }
 

--- a/executor/batch/batch.go
+++ b/executor/batch/batch.go
@@ -59,9 +59,9 @@ func NewBatchSubmitterV1(
 	cfg nodetypes.NodeConfig,
 	batchCfg executortypes.BatchConfig,
 	db types.DB, logger *zap.Logger,
-	chainID, homePath, bech32Prefix string,
+	chainID, homePath string,
 ) *BatchSubmitter {
-	appCodec, txConfig, err := childprovider.GetCodec(bech32Prefix)
+	appCodec, txConfig, err := childprovider.GetCodec(cfg.Bech32Prefix)
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ func NewBatchSubmitterV1(
 }
 
 func (bs *BatchSubmitter) Initialize(ctx context.Context, processedHeight int64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
-	err := bs.node.Initialize(ctx, processedHeight)
+	err := bs.node.Initialize(ctx, processedHeight, nil)
 	if err != nil {
 		return err
 	}

--- a/executor/celestia/celestia.go
+++ b/executor/celestia/celestia.go
@@ -52,7 +52,7 @@ type Celestia struct {
 
 func NewDACelestia(
 	version uint8, cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix, batchSubmitter string,
+	db types.DB, logger *zap.Logger,
 ) *Celestia {
 	c := &Celestia{
 		version: version,
@@ -65,13 +65,12 @@ func NewDACelestia(
 		msgQueue:      make([]sdk.Msg, 0),
 	}
 
-	appCodec, txConfig, err := createCodec(bech32Prefix)
+	appCodec, txConfig, err := createCodec(cfg.Bech32Prefix)
 	if err != nil {
 		panic(err)
 	}
 
 	if cfg.BroadcasterConfig != nil {
-		cfg.BroadcasterConfig.KeyringConfig.Address = batchSubmitter
 		cfg.BroadcasterConfig.BuildTxWithMessages = c.BuildTxWithMessages
 		cfg.BroadcasterConfig.PendingTxToProcessedMsgs = c.PendingTxToProcessedMsgs
 	}
@@ -95,8 +94,8 @@ func createCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (c *Celestia) Initialize(ctx context.Context, batch batchNode, bridgeId uint64) error {
-	err := c.node.Initialize(ctx, 0)
+func (c *Celestia) Initialize(ctx context.Context, batch batchNode, bridgeId uint64, keyringConfig *btypes.KeyringConfig) error {
+	err := c.node.Initialize(ctx, 0, keyringConfig)
 	if err != nil {
 		return err
 	}

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -53,7 +53,7 @@ func NewChildV1(
 	}
 }
 
-func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	l2Sequence, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo)
 	if err != nil {
 		return err

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -46,15 +46,15 @@ type Child struct {
 
 func NewChildV1(
 	cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix string,
+	db types.DB, logger *zap.Logger,
 ) *Child {
 	return &Child{
-		BaseChild: childprovider.NewBaseChildV1(cfg, db, logger, bech32Prefix),
+		BaseChild: childprovider.NewBaseChildV1(cfg, db, logger),
 	}
 }
 
-func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
-	l2Sequence, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo)
+func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse, keyringConfig *btypes.KeyringConfig) error {
+	l2Sequence, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo, keyringConfig)
 	if err != nil {
 		return err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -177,6 +177,9 @@ func (ex *Executor) makeDANode(ctx context.Context, bridgeInfo ophosttypes.Query
 	}
 
 	batchInfo := ex.batch.BatchInfo()
+	if batchInfo == nil {
+		return nil, errors.New("batch info is not set")
+	}
 	switch batchInfo.BatchInfo.ChainType {
 	case ophosttypes.BatchInfo_CHAIN_TYPE_INITIA:
 		// might not exist

--- a/executor/host/host.go
+++ b/executor/host/host.go
@@ -49,19 +49,15 @@ type Host struct {
 
 func NewHostV1(
 	cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix, batchSubmitter string,
+	db types.DB, logger *zap.Logger,
 ) *Host {
-	if cfg.BroadcasterConfig != nil && batchSubmitter != "" {
-		cfg.BroadcasterConfig.Bech32Prefix = bech32Prefix
-		cfg.BroadcasterConfig.KeyringConfig.Address = batchSubmitter
-	}
 	return &Host{
-		BaseHost: hostprovider.NewBaseHostV1(cfg, db, logger, bech32Prefix),
+		BaseHost: hostprovider.NewBaseHostV1(cfg, db, logger),
 	}
 }
 
-func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, batch batchNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
-	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo)
+func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, batch batchNode, bridgeInfo ophosttypes.QueryBridgeResponse, keyringConfig *btypes.KeyringConfig) error {
+	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo, keyringConfig)
 	if err != nil {
 		return err
 	}
@@ -75,8 +71,8 @@ func (h *Host) Initialize(ctx context.Context, processedHeight int64, child chil
 	return nil
 }
 
-func (h *Host) InitializeDA(ctx context.Context, bridgeInfo ophosttypes.QueryBridgeResponse) error {
-	err := h.BaseHost.Initialize(ctx, 0, bridgeInfo)
+func (h *Host) InitializeDA(ctx context.Context, bridgeInfo ophosttypes.QueryBridgeResponse, keyringConfig *btypes.KeyringConfig) error {
+	err := h.BaseHost.Initialize(ctx, 0, bridgeInfo, keyringConfig)
 	if err != nil {
 		return err
 	}

--- a/executor/host/host.go
+++ b/executor/host/host.go
@@ -7,7 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
 
 	executortypes "github.com/initia-labs/opinit-bots/executor/types"
@@ -61,7 +60,7 @@ func NewHostV1(
 	}
 }
 
-func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, batch batchNode, bridgeInfo opchildtypes.BridgeInfo) error {
+func (h *Host) Initialize(ctx context.Context, processedHeight int64, child childNode, batch batchNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	err := h.BaseHost.Initialize(ctx, processedHeight, bridgeInfo)
 	if err != nil {
 		return err
@@ -76,7 +75,7 @@ func (h *Host) Initialize(ctx context.Context, processedHeight int64, child chil
 	return nil
 }
 
-func (h *Host) InitializeDA(ctx context.Context, bridgeInfo opchildtypes.BridgeInfo) error {
+func (h *Host) InitializeDA(ctx context.Context, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	err := h.BaseHost.Initialize(ctx, 0, bridgeInfo)
 	if err != nil {
 		return err

--- a/node/broadcaster/broadcaster.go
+++ b/node/broadcaster/broadcaster.go
@@ -95,23 +95,28 @@ func NewBroadcaster(
 	if rpcClient == nil {
 		return nil, errors.New("rpc client is nil")
 	}
+	return b, nil
+}
+
+func (b *Broadcaster) Initialize(ctx context.Context, status *rpccoretypes.ResultStatus, keyringConfig *btypes.KeyringConfig) error {
+	err := keyringConfig.Validate()
+	if err != nil {
+		return err
+	}
 
 	// setup keyring
-	keyBase, keyringRecord, err := cfg.GetKeyringRecord(cdc, cfg.ChainID)
+	keyBase, keyringRecord, err := b.cfg.GetKeyringRecord(b.cdc, keyringConfig)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	b.keyBase = keyBase
 	addr, err := keyringRecord.GetAddress()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	b.keyAddress = addr
 	b.keyName = keyringRecord.Name
-	return b, nil
-}
 
-func (b *Broadcaster) Initialize(ctx context.Context, status *rpccoretypes.ResultStatus) error {
 	// prepare broadcaster
 	return b.prepareBroadcaster(ctx, status.SyncInfo.LatestBlockTime)
 }

--- a/node/broadcaster/types/config.go
+++ b/node/broadcaster/types/config.go
@@ -86,6 +86,10 @@ func (bc BroadcasterConfig) Validate() error {
 }
 
 func (bc BroadcasterConfig) GetKeyringRecord(cdc codec.Codec, keyringConfig *KeyringConfig) (keyring.Keyring, *keyring.Record, error) {
+	if keyringConfig == nil {
+		return nil, nil, fmt.Errorf("keyring config cannot be nil")
+	}
+
 	keyBase, err := keys.GetKeyBase(bc.ChainID, bc.HomePath, cdc, nil)
 	if err != nil {
 		return nil, nil, err

--- a/node/broadcaster/types/config.go
+++ b/node/broadcaster/types/config.go
@@ -39,9 +39,6 @@ type BroadcasterConfig struct {
 
 	// HomePath is the path to the keyring.
 	HomePath string
-
-	// KeyringConfig is the keyring configuration.
-	KeyringConfig KeyringConfig
 }
 
 func (bc *BroadcasterConfig) WithPendingTxToProcessedMsgsFn(fn PendingTxToProcessedMsgsFn) {

--- a/node/node.go
+++ b/node/node.go
@@ -8,6 +8,7 @@ import (
 
 	"cosmossdk.io/core/address"
 	"github.com/initia-labs/opinit-bots/node/broadcaster"
+	btypes "github.com/initia-labs/opinit-bots/node/broadcaster/types"
 	"github.com/initia-labs/opinit-bots/node/rpcclient"
 	nodetypes "github.com/initia-labs/opinit-bots/node/types"
 	"github.com/initia-labs/opinit-bots/types"
@@ -85,7 +86,7 @@ func NewNode(cfg nodetypes.NodeConfig, db types.DB, logger *zap.Logger, cdc code
 // StartHeight is the height to start processing.
 // If it is 0, the latest height is used.
 // If the latest height exists in the database, this is ignored.
-func (n *Node) Initialize(ctx context.Context, processedHeight int64) (err error) {
+func (n *Node) Initialize(ctx context.Context, processedHeight int64, keyringConfig *btypes.KeyringConfig) (err error) {
 	// check if node is catching up
 	status, err := n.rpcClient.Status(ctx)
 	if err != nil {
@@ -95,7 +96,7 @@ func (n *Node) Initialize(ctx context.Context, processedHeight int64) (err error
 		return errors.New("node is catching up")
 	}
 	if n.broadcaster != nil {
-		err = n.broadcaster.Initialize(ctx, status)
+		err = n.broadcaster.Initialize(ctx, status, keyringConfig)
 		if err != nil {
 			return err
 		}

--- a/node/types/config.go
+++ b/node/types/config.go
@@ -20,6 +20,9 @@ type NodeConfig struct {
 	// BlockProcessType is the type of block process.
 	ProcessType BlockProcessType
 
+	// Bech32Prefix is the Bech32 prefix of the chain.
+	Bech32Prefix string
+
 	// You can leave it empty, then the bot will skip the transaction submission.
 	BroadcasterConfig *btypes.BroadcasterConfig
 }
@@ -31,6 +34,10 @@ func (nc NodeConfig) Validate() error {
 
 	if nc.ProcessType > PROCESS_TYPE_ONLY_BROADCAST {
 		return fmt.Errorf("invalid process type")
+	}
+
+	if nc.Bech32Prefix == "" {
+		return fmt.Errorf("bech32 prefix is empty")
 	}
 
 	// Validated in broadcaster

--- a/provider/child/child.go
+++ b/provider/child/child.go
@@ -28,7 +28,7 @@ type BaseChild struct {
 	node *node.Node
 	mk   *merkle.Merkle
 
-	bridgeInfo opchildtypes.BridgeInfo
+	bridgeInfo ophosttypes.QueryBridgeResponse
 
 	initializeTreeFn func(int64) (bool, error)
 
@@ -89,7 +89,7 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (b *BaseChild) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, bridgeInfo opchildtypes.BridgeInfo) (uint64, error) {
+func (b *BaseChild) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, bridgeInfo ophosttypes.QueryBridgeResponse) (uint64, error) {
 	err := b.node.Initialize(ctx, processedHeight)
 	if err != nil {
 		return 0, err
@@ -162,11 +162,11 @@ func (b BaseChild) HasKey() bool {
 	return b.node.HasBroadcaster()
 }
 
-func (b *BaseChild) SetBridgeInfo(bridgeInfo opchildtypes.BridgeInfo) {
+func (b *BaseChild) SetBridgeInfo(bridgeInfo ophosttypes.QueryBridgeResponse) {
 	b.bridgeInfo = bridgeInfo
 }
 
-func (b BaseChild) BridgeInfo() opchildtypes.BridgeInfo {
+func (b BaseChild) BridgeInfo() ophosttypes.QueryBridgeResponse {
 	return b.bridgeInfo
 }
 

--- a/provider/child/child.go
+++ b/provider/child/child.go
@@ -44,9 +44,9 @@ type BaseChild struct {
 
 func NewBaseChildV1(
 	cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix string,
+	db types.DB, logger *zap.Logger,
 ) *BaseChild {
-	appCodec, txConfig, err := GetCodec(bech32Prefix)
+	appCodec, txConfig, err := GetCodec(cfg.Bech32Prefix)
 	if err != nil {
 		panic(err)
 	}
@@ -89,8 +89,8 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (b *BaseChild) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, bridgeInfo ophosttypes.QueryBridgeResponse) (uint64, error) {
-	err := b.node.Initialize(ctx, processedHeight)
+func (b *BaseChild) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, bridgeInfo ophosttypes.QueryBridgeResponse, keyringConfig *btypes.KeyringConfig) (uint64, error) {
+	err := b.node.Initialize(ctx, processedHeight, keyringConfig)
 	if err != nil {
 		return 0, err
 	}

--- a/provider/host/host.go
+++ b/provider/host/host.go
@@ -38,9 +38,9 @@ type BaseHost struct {
 }
 
 func NewBaseHostV1(cfg nodetypes.NodeConfig,
-	db types.DB, logger *zap.Logger, bech32Prefix string,
+	db types.DB, logger *zap.Logger,
 ) *BaseHost {
-	appCodec, txConfig, err := GetCodec(bech32Prefix)
+	appCodec, txConfig, err := GetCodec(cfg.Bech32Prefix)
 	if err != nil {
 		panic(err)
 	}
@@ -78,8 +78,8 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (b *BaseHost) Initialize(ctx context.Context, processedHeight int64, bridgeInfo ophosttypes.QueryBridgeResponse) error {
-	err := b.node.Initialize(ctx, processedHeight)
+func (b *BaseHost) Initialize(ctx context.Context, processedHeight int64, bridgeInfo ophosttypes.QueryBridgeResponse, keyringConfig *btypes.KeyringConfig) error {
+	err := b.node.Initialize(ctx, processedHeight, keyringConfig)
 	if err != nil {
 		return err
 	}

--- a/provider/host/host.go
+++ b/provider/host/host.go
@@ -10,7 +10,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 
-	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
 	"github.com/initia-labs/OPinit/x/ophost"
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
 
@@ -26,7 +25,7 @@ type BaseHost struct {
 
 	node *node.Node
 
-	bridgeInfo opchildtypes.BridgeInfo
+	bridgeInfo ophosttypes.QueryBridgeResponse
 
 	cfg    nodetypes.NodeConfig
 	db     types.DB
@@ -79,7 +78,7 @@ func GetCodec(bech32Prefix string) (codec.Codec, client.TxConfig, error) {
 	})
 }
 
-func (b *BaseHost) Initialize(ctx context.Context, processedHeight int64, bridgeInfo opchildtypes.BridgeInfo) error {
+func (b *BaseHost) Initialize(ctx context.Context, processedHeight int64, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	err := b.node.Initialize(ctx, processedHeight)
 	if err != nil {
 		return err
@@ -121,11 +120,11 @@ func (b BaseHost) OracleEnabled() bool {
 	return b.bridgeInfo.BridgeConfig.OracleEnabled
 }
 
-func (b *BaseHost) SetBridgeInfo(bridgeInfo opchildtypes.BridgeInfo) {
+func (b *BaseHost) SetBridgeInfo(bridgeInfo ophosttypes.QueryBridgeResponse) {
 	b.bridgeInfo = bridgeInfo
 }
 
-func (b BaseHost) BridgeInfo() opchildtypes.BridgeInfo {
+func (b BaseHost) BridgeInfo() ophosttypes.QueryBridgeResponse {
 	return b.bridgeInfo
 }
 


### PR DESCRIPTION
`OutputSubmitter` now only needs to register the proposer that exists in bridge info to the keyring instead of writing the keyname in config.

`EnableOutputSubmitter` must be set to true to make OutputSubmitter work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration management for bridge information and keyring handling across various components.
	- Introduced `Bech32Prefix` field in node configuration for improved chain prefix management.

- **Bug Fixes**
	- Streamlined initialization processes to ensure compatibility with new parameter types, enhancing overall stability.

- **Documentation**
	- Updated method signatures and configuration structures for clarity and improved usability.

- **Refactor**
	- Simplified method signatures by removing unnecessary parameters, improving code readability and maintainability.

- **Chores**
	- Removed deprecated import statements and adjusted dependencies accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->