### PR TITLE
Fix/config enable to disable

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -48,13 +48,13 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   // If you don't want to use the bridge executor feature, you can leave it empty.
   "bridge_executor": "",
 
-	// DisableOutputSubmitter is the flag to disable the output submitter.
-	// If it is true, the output submitter will not be started.
-	"disable_output_submitter": false,
+  // DisableOutputSubmitter is the flag to disable the output submitter.
+  // If it is true, the output submitter will not be started.
+  "disable_output_submitter": false,
 
-	// DisableBatchSubmitter is the flag to disable the batch submitter.
-	// If it is true, the batch submitter will not be started.
-	"disable_batch_submitter": false,
+  // DisableBatchSubmitter is the flag to disable the batch submitter.
+  // If it is true, the batch submitter will not be started.
+  "disable_batch_submitter": false,
 
   // MaxChunks is the maximum number of chunks in a batch.
   "max_chunks": 5000,

--- a/executor/README.md
+++ b/executor/README.md
@@ -48,13 +48,13 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   // If you don't want to use the bridge executor feature, you can leave it empty.
   "bridge_executor": "",
 
-	// EnableOutputSubmitter is the flag to enable the output submitter.
-	// If it is false, the output submitter will not be started.
-	"enable_output_submitter": true,
+	// DisableOutputSubmitter is the flag to disable the output submitter.
+	// If it is true, the output submitter will not be started.
+	"disable_output_submitter": false,
 
-	// EnableBatchSubmitter is the flag to enable the batch submitter.
-	// If it is false, the batch submitter will not be started.
-	"enable_batch_submitter": true,
+	// DisableBatchSubmitter is the flag to disable the batch submitter.
+	// If it is true, the batch submitter will not be started.
+	"disable_batch_submitter": false,
 
   // MaxChunks is the maximum number of chunks in a batch.
   "max_chunks": 5000,

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -172,7 +172,7 @@ func (ex *Executor) RegisterQuerier() {
 }
 
 func (ex *Executor) makeDANode(ctx context.Context, bridgeInfo ophosttypes.QueryBridgeResponse, daKeyringConfig *btypes.KeyringConfig) (executortypes.DANode, error) {
-	if !ex.cfg.EnableBatchSubmitter {
+	if ex.cfg.DisableBatchSubmitter {
 		return batch.NewNoopDA(), nil
 	}
 
@@ -271,7 +271,7 @@ func (ex *Executor) getProcessedHeights(ctx context.Context, bridgeId uint64) (l
 }
 
 func (ex *Executor) getKeyringConfigs(bridgeInfo ophosttypes.QueryBridgeResponse) (hostKeyringConfig *btypes.KeyringConfig, childKeyringConfig *btypes.KeyringConfig, daKeyringConfig *btypes.KeyringConfig) {
-	if ex.cfg.EnableOutputSubmitter {
+	if !ex.cfg.DisableOutputSubmitter {
 		hostKeyringConfig = &btypes.KeyringConfig{
 			Address: bridgeInfo.BridgeConfig.Proposer,
 		}
@@ -283,7 +283,7 @@ func (ex *Executor) getKeyringConfigs(bridgeInfo ophosttypes.QueryBridgeResponse
 		}
 	}
 
-	if ex.cfg.EnableBatchSubmitter {
+	if !ex.cfg.DisableBatchSubmitter {
 		daKeyringConfig = &btypes.KeyringConfig{
 			Address: bridgeInfo.BridgeConfig.BatchInfo.Submitter,
 		}

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -50,13 +50,13 @@ type Config struct {
 	// If you don't want to use the bridge executor feature, you can leave it empty.
 	BridgeExecutor string `json:"bridge_executor"`
 
-	// EnableOutputSubmitter is the flag to enable the output submitter.
-	// If it is false, the output submitter will not be started.
-	EnableOutputSubmitter bool `json:"enable_output_submitter"`
+	// DisableOutputSubmitter is the flag to disable the output submitter.
+	// If it is true, the output submitter will not be started.
+	DisableOutputSubmitter bool `json:"disable_output_submitter"`
 
-	// EnableBatchSubmitter is the flag to enable the batch submitter.
-	// If it is false, the batch submitter will not be started.
-	EnableBatchSubmitter bool `json:"enable_batch_submitter"`
+	// DisableBatchSubmitter is the flag to disable the batch submitter.
+	// If it is true, the batch submitter will not be started.
+	DisableBatchSubmitter bool `json:"disable_batch_submitter"`
 
 	// MaxChunks is the maximum number of chunks in a batch.
 	MaxChunks int64 `json:"max_chunks"`
@@ -114,9 +114,9 @@ func DefaultConfig() *Config {
 			TxTimeout:     60,
 		},
 
-		BridgeExecutor:        "",
-		EnableOutputSubmitter: true,
-		EnableBatchSubmitter:  true,
+		BridgeExecutor:         "",
+		DisableOutputSubmitter: false,
+		DisableBatchSubmitter:  false,
 
 		MaxChunks:         5000,
 		MaxChunkSize:      300000,  // 300KB
@@ -187,7 +187,7 @@ func (cfg Config) L1NodeConfig(homePath string) nodetypes.NodeConfig {
 		Bech32Prefix: cfg.L1Node.Bech32Prefix,
 	}
 
-	if cfg.EnableOutputSubmitter {
+	if !cfg.DisableOutputSubmitter {
 		nc.BroadcasterConfig = &btypes.BroadcasterConfig{
 			ChainID:       cfg.L1Node.ChainID,
 			GasPrice:      cfg.L1Node.GasPrice,
@@ -229,7 +229,7 @@ func (cfg Config) DANodeConfig(homePath string) nodetypes.NodeConfig {
 		Bech32Prefix: cfg.DANode.Bech32Prefix,
 	}
 
-	if cfg.EnableBatchSubmitter {
+	if !cfg.DisableBatchSubmitter {
 		nc.BroadcasterConfig = &btypes.BroadcasterConfig{
 			ChainID:       cfg.DANode.ChainID,
 			GasPrice:      cfg.DANode.GasPrice,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration options for output and batch submitters to focus on disabling rather than enabling.
	- Introduced new flags: `disable_output_submitter` and `disable_batch_submitter`, with default values set to `false`.

- **Documentation**
	- Revised comments in the configuration documentation to clarify the new naming conventions and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->