### PR TITLE
add feegrant msg to grant-oracle cmd

### DIFF
--- a/challenger/child/child.go
+++ b/challenger/child/child.go
@@ -56,8 +56,23 @@ func NewChildV1(
 	}
 }
 
-func (ch *Child) Initialize(ctx context.Context, processedHeight int64, startOutputIndex uint64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse, challenger challenger) (time.Time, error) {
-	_, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo, nil, nil)
+func (ch *Child) Initialize(
+	ctx context.Context,
+	processedHeight int64,
+	startOutputIndex uint64,
+	host hostNode,
+	bridgeInfo ophosttypes.QueryBridgeResponse,
+	challenger challenger,
+) (time.Time, error) {
+	_, err := ch.BaseChild.Initialize(
+		ctx,
+		processedHeight,
+		startOutputIndex,
+		bridgeInfo,
+		nil,
+		nil,
+		true,
+	)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/cmd/opinitd/tx.go
+++ b/cmd/opinitd/tx.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"cosmossdk.io/x/feegrant"
+
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/initia-labs/opinit-bots/bot"

--- a/cmd/opinitd/tx.go
+++ b/cmd/opinitd/tx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"cosmossdk.io/x/feegrant"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/initia-labs/opinit-bots/bot"
@@ -69,7 +70,17 @@ func txGrantOracleCmd(baseCtx *cmdContext) *cobra.Command {
 				return err
 			}
 
-			txBytes, _, err := account.BuildTxWithMessages(ctx, []sdk.Msg{grantMsg})
+			msgAllowance, err := feegrant.NewAllowedMsgAllowance(&feegrant.BasicAllowance{}, []string{types.MsgUpdateOracleTypeUrl, types.MsgAuthzExecTypeUrl})
+			if err != nil {
+				return err
+			}
+
+			feegrantMsg, err := feegrant.NewMsgGrantAllowance(msgAllowance, account.GetAddress(), oracleAddress)
+			if err != nil {
+				return err
+			}
+
+			txBytes, _, err := account.BuildTxWithMessages(ctx, []sdk.Msg{grantMsg, feegrantMsg})
 			if err != nil {
 				return errors.Wrapf(err, "simulation failed")
 			}

--- a/executor/README.md
+++ b/executor/README.md
@@ -86,7 +86,11 @@ To configure the Executor, fill in the values in the `~/.opinit/executor.json` f
   "l2_start_height": 0,
   // StartBatchHeight is the height to start the batch. If it is 0, it will start from the latest height.
   // If the latest height stored in the db is not 0, this config is ignored.
-  "batch_start_height": 0
+  "batch_start_height": 0,
+  // DisableDeleteFutureWithdrawal is the flag to disable the deletion of future withdrawal.
+  // when the bot is rolled back, it will delete the future withdrawals from DB.
+  // If it is true, it will not delete the future withdrawals.
+  "disable_delete_future_withdrawal": false,
 }
 ```
 

--- a/executor/child/child.go
+++ b/executor/child/child.go
@@ -66,8 +66,17 @@ func (ch *Child) Initialize(
 	bridgeInfo ophosttypes.QueryBridgeResponse,
 	keyringConfig *btypes.KeyringConfig,
 	oracleKeyringConfig *btypes.KeyringConfig,
+	disableDeleteFutureWithdrawals bool,
 ) error {
-	l2Sequence, err := ch.BaseChild.Initialize(ctx, processedHeight, startOutputIndex, bridgeInfo, keyringConfig, oracleKeyringConfig)
+	l2Sequence, err := ch.BaseChild.Initialize(
+		ctx,
+		processedHeight,
+		startOutputIndex,
+		bridgeInfo,
+		keyringConfig,
+		oracleKeyringConfig,
+		disableDeleteFutureWithdrawals,
+	)
 	if err != nil {
 		return err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -104,7 +104,16 @@ func (ex *Executor) Initialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = ex.child.Initialize(ctx, childProcessedHeight, processedOutputIndex+1, ex.host, *bridgeInfo, childKeyringConfig, childOracleKeyringConfig)
+	err = ex.child.Initialize(
+		ctx,
+		childProcessedHeight,
+		processedOutputIndex+1,
+		ex.host,
+		*bridgeInfo,
+		childKeyringConfig,
+		childOracleKeyringConfig,
+		ex.cfg.DisableDeleteFutureWithdrawal,
+	)
 	if err != nil {
 		return err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -327,7 +327,8 @@ func (ex *Executor) getKeyringConfigs(bridgeInfo ophosttypes.QueryBridgeResponse
 
 		if bridgeInfo.BridgeConfig.OracleEnabled && ex.cfg.OracleBridgeExecutor != "" {
 			childOracleKeyringConfig = &btypes.KeyringConfig{
-				Name: ex.cfg.OracleBridgeExecutor,
+				Name:       ex.cfg.OracleBridgeExecutor,
+				FeeGranter: childKeyringConfig,
 			}
 		}
 	}

--- a/executor/types/config.go
+++ b/executor/types/config.go
@@ -88,6 +88,11 @@ type Config struct {
 	// BatchStartHeight is the height to start the batch. If it is 0, it will start from the latest height.
 	// If the latest height stored in the db is not 0, this config is ignored.
 	BatchStartHeight int64 `json:"batch_start_height"`
+
+	// DisableDeleteFutureWithdrawal is the flag to disable the deletion of future withdrawal.
+	// when the bot is rolled back, it will delete the future withdrawals from DB.
+	// If it is true, it will not delete the future withdrawals.
+	DisableDeleteFutureWithdrawal bool `json:"disable_delete_future_withdrawal"`
 }
 
 func DefaultConfig() *Config {
@@ -137,10 +142,11 @@ func DefaultConfig() *Config {
 		MaxChunkSize:      300000,  // 300KB
 		MaxSubmissionTime: 60 * 60, // 1 hour
 
-		DisableAutoSetL1Height: false,
-		L1StartHeight:          0,
-		L2StartHeight:          0,
-		BatchStartHeight:       0,
+		DisableAutoSetL1Height:        false,
+		L1StartHeight:                 0,
+		L2StartHeight:                 0,
+		BatchStartHeight:              0,
+		DisableDeleteFutureWithdrawal: false,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	cosmossdk.io/depinject v1.0.0 // indirect
 	cosmossdk.io/log v1.4.1 // indirect
 	cosmossdk.io/store v1.1.1 // indirect
+	cosmossdk.io/x/feegrant v0.1.1 // indirect
 	cosmossdk.io/x/upgrade v0.1.4 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cosmossdk.io/core v0.11.1
 	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/math v1.3.0
+	cosmossdk.io/x/feegrant v0.1.1
 	cosmossdk.io/x/tx v0.13.5
 	github.com/celestiaorg/go-square/v2 v2.0.0
 	github.com/cometbft/cometbft v0.38.12
@@ -33,7 +34,6 @@ require (
 	cosmossdk.io/depinject v1.0.0 // indirect
 	cosmossdk.io/log v1.4.1 // indirect
 	cosmossdk.io/store v1.1.1 // indirect
-	cosmossdk.io/x/feegrant v0.1.1 // indirect
 	cosmossdk.io/x/upgrade v0.1.4 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect

--- a/node/broadcaster/account.go
+++ b/node/broadcaster/account.go
@@ -95,6 +95,19 @@ func NewBroadcasterAccount(cfg btypes.BroadcasterConfig, cdc codec.Codec, txConf
 		WithKeybase(keyBase).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT)
 
+	if keyringConfig.FeeGranter != nil {
+		// setup keyring
+		_, feeGranterKeyringRecord, err := cfg.GetKeyringRecord(cdc, keyringConfig.FeeGranter)
+		if err != nil {
+			return nil, err
+		}
+
+		feeGranter, err := feeGranterKeyringRecord.GetAddress()
+		if err != nil {
+			return nil, err
+		}
+		b.txf = b.txf.WithFeeGranter(feeGranter)
+	}
 	return b, nil
 }
 

--- a/node/broadcaster/types/config.go
+++ b/node/broadcaster/types/config.go
@@ -89,6 +89,9 @@ type KeyringConfig struct {
 	// Address of key in keyring
 	Address string `json:"address"`
 
+	// FeeGranter is the fee granter.
+	FeeGranter *KeyringConfig
+
 	// BuildTxWithMessages is the function to build a transaction with messages.
 	BuildTxWithMessages BuildTxWithMessagesFn
 

--- a/provider/child/child.go
+++ b/provider/child/child.go
@@ -107,6 +107,7 @@ func (b *BaseChild) Initialize(
 	bridgeInfo ophosttypes.QueryBridgeResponse,
 	keyringConfig *btypes.KeyringConfig,
 	oracleKeyringConfig *btypes.KeyringConfig,
+	disableDeleteFutureWithdrawals bool,
 ) (uint64, error) {
 	b.SetBridgeInfo(bridgeInfo)
 
@@ -117,14 +118,16 @@ func (b *BaseChild) Initialize(
 
 	var l2Sequence uint64
 	if b.node.HeightInitialized() {
-		l2Sequence, err = b.QueryNextL2Sequence(ctx, processedHeight)
-		if err != nil {
-			return 0, err
-		}
+		if !disableDeleteFutureWithdrawals {
+			l2Sequence, err = b.QueryNextL2Sequence(ctx, processedHeight)
+			if err != nil {
+				return 0, err
+			}
 
-		err = b.mk.DeleteFutureFinalizedTrees(l2Sequence)
-		if err != nil {
-			return 0, err
+			err = b.mk.DeleteFutureFinalizedTrees(l2Sequence)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		version := types.MustInt64ToUint64(processedHeight)

--- a/types/const.go
+++ b/types/const.go
@@ -10,4 +10,5 @@ const (
 	DACelestiaName = "da_celestia"
 
 	MsgUpdateOracleTypeUrl = "/opinit.opchild.v1.MsgUpdateOracle"
+	MsgAuthzExecTypeUrl    = "/cosmos.authz.v1beta1.MsgExec"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced fee grant functionality for granting oracle permissions, enhancing transaction capabilities.
	- Added a `FeeGranter` field to keyring configurations, improving transaction fee management.
	- New constant `MsgAuthzExecTypeUrl` added for message type definitions.
	- New configuration option `disable_delete_future_withdrawal` added to control future withdrawal deletions during rollbacks.

- **Bug Fixes**
	- Enhanced error handling for fee granter retrieval in transaction configurations.

- **Chores**
	- Updated dependencies in `go.mod` to include new indirect dependency and adjusted existing ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->