### PR TITLE
feat: introduce `broadcastProcessedMsgsMut` to prevent race condition at broadcast

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/executor/db.go
+++ b/executor/db.go
@@ -141,7 +141,7 @@ func Migration019_1(db types.DB) error {
 
 			treeHeight := types.MustIntToUint8(bits.Len64(workingTree.LeafCount - 1))
 			if workingTree.LeafCount <= 1 {
-				treeHeight = uint8(workingTree.LeafCount) //nolint
+				treeHeight = uint8(workingTree.LeafCount) //nolint:gomnd
 			}
 
 			treeRootHash := workingTree.LastSiblings[treeHeight]

--- a/executor/db.go
+++ b/executor/db.go
@@ -141,7 +141,7 @@ func Migration019_1(db types.DB) error {
 
 			treeHeight := types.MustIntToUint8(bits.Len64(workingTree.LeafCount - 1))
 			if workingTree.LeafCount <= 1 {
-				treeHeight = uint8(workingTree.LeafCount) //nolint:gomnd
+				treeHeight = uint8(workingTree.LeafCount) //nolint
 			}
 
 			treeRootHash := workingTree.LastSiblings[treeHeight]

--- a/node/broadcaster/broadcaster.go
+++ b/node/broadcaster/broadcaster.go
@@ -42,11 +42,12 @@ type Broadcaster struct {
 	txChannel        chan btypes.ProcessedMsgs
 	txChannelStopped chan struct{}
 
-	pendingTxMu *sync.Mutex
 	// local pending txs, which is following Queue data structure
-	pendingTxs []btypes.PendingTxInfo
-
+	pendingTxs                []btypes.PendingTxInfo
 	pendingProcessedMsgsBatch []btypes.ProcessedMsgs
+
+	pendingTxMu               *sync.Mutex
+	broadcastProcessedMsgsMut *sync.Mutex
 
 	syncedHeight int64
 }
@@ -71,9 +72,11 @@ func NewBroadcaster(
 		txChannel:        make(chan btypes.ProcessedMsgs),
 		txChannelStopped: make(chan struct{}),
 
-		pendingTxMu:               &sync.Mutex{},
 		pendingTxs:                make([]btypes.PendingTxInfo, 0),
 		pendingProcessedMsgsBatch: make([]btypes.ProcessedMsgs, 0),
+
+		pendingTxMu:               &sync.Mutex{},
+		broadcastProcessedMsgsMut: &sync.Mutex{},
 	}
 
 	// validate broadcaster config

--- a/node/node.go
+++ b/node/node.go
@@ -109,6 +109,9 @@ func (n *Node) Initialize(ctx types.Context, processedHeight int64, keyringConfi
 		if err != nil {
 			return err
 		}
+
+		// broadcast pending msgs first before executing block process looper
+		go n.broadcaster.BroadcastPendingProcessedMsgs()
 	}
 
 	// if not found, initialize the height
@@ -147,9 +150,6 @@ func (n *Node) start(ctx types.Context) {
 
 			return n.broadcaster.Start(ctx)
 		})
-
-		// broadcast pending msgs first before executing block process looper
-		n.broadcaster.BroadcastPendingProcessedMsgs()
 	}
 
 	enableEventHandler := true


### PR DESCRIPTION
We have logic in place to clear pending transactions at boot time. However, during this process, other tasks may insert new messages for broadcasting, potentially disrupting the bridge sequence logic.

To prevent this, we’ve updated the process to pass all broadcast messages at once and hold a lock during the broadcast loop to maintain the sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the tooling environment to use a more recent Go release for improved code quality checks.
- **Refactor**
	- Streamlined the message broadcasting system to support batch processing, enhancing overall performance and reliability.
	- Adjusted the timing of message broadcasting to occur during the initialization phase, improving the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->