### PR TITLE
chore: disable fiber's startup message

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ type Server struct {
 }
 
 func NewServer(cfg types.ServerConfig) *Server {
-	app := fiber.New()
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 	app.Use(cors.New(cors.Config{
 		AllowOrigins: cfg.AllowOrigins,
 		AllowHeaders: cfg.AllowHeaders,


### PR DESCRIPTION
fiber's startup message doesn't help with collecting logs lol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - The application’s initialization process has been streamlined by removing the startup message, resulting in a cleaner and less cluttered launch experience while keeping core functionality intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->