### PR TITLE
fix: remove unnecessary catching up check

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -101,9 +101,6 @@ func (n *Node) Initialize(ctx types.Context, processedHeight int64, keyringConfi
 	if err != nil {
 		return err
 	}
-	if status.SyncInfo.CatchingUp {
-		return errors.New("node is catching up")
-	}
 	if n.HasBroadcaster() {
 		err = n.broadcaster.Initialize(ctx, status, keyringConfig)
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Initialization now proceeds regardless of the node's catching-up status, removing the previous restriction that halted setup during catch-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->