### PR TITLE
feat: use memo to create different tx hash

### DIFF
--- a/node/broadcaster/account.go
+++ b/node/broadcaster/account.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/rand"
 	"github.com/getsentry/sentry-go"
 	"github.com/initia-labs/opinit-bots/keys"
 	btypes "github.com/initia-labs/opinit-bots/node/broadcaster/types"
@@ -267,7 +268,8 @@ func (b BroadcasterAccount) SimulateAndSignTx(ctx context.Context, msgs ...sdk.M
 		return nil, err
 	}
 
-	b.txf = b.txf.WithGas(adjusted)
+	// create random string memo to avoid tx hash collision
+	b.txf = b.txf.WithGas(adjusted).WithMemo(rand.Str(10))
 
 	unlock := keys.SetSDKConfigContext(b.Bech32Prefix())
 	defer unlock()

--- a/node/broadcaster/tx.go
+++ b/node/broadcaster/tx.go
@@ -105,6 +105,8 @@ func (b *Broadcaster) handleProcessedMsgs(ctx types.Context, data btypes.Process
 		return errors.Wrapf(err, "simulation failed")
 	}
 
+	ctx.Logger().Debug("broadcast tx", zap.String("tx_hash", txHash), zap.Uint64("sequence", sequence))
+
 	res, err := b.rpcClient.BroadcastTxSync(ctx, txBytes)
 	if err != nil {
 		// TODO: handle error, may repeat sending tx
@@ -113,8 +115,6 @@ func (b *Broadcaster) handleProcessedMsgs(ctx types.Context, data btypes.Process
 	if res.Code != 0 {
 		return fmt.Errorf("broadcast txs: %s", res.Log)
 	}
-
-	ctx.Logger().Debug("broadcast tx", zap.String("tx_hash", txHash), zap.Uint64("sequence", sequence))
 
 	err = DeleteProcessedMsgs(b.db, data)
 	if err != nil {


### PR DESCRIPTION
# Description

Seems Celestia rejects a tx from the mempool if that tx was rejected recently, to prevent that we use memo to populate different tx hash.

https://github.com/celestiaorg/celestia-core/commit/6aac2abf783f75bc7b69aaf484d9819e787ccb63#diff-297b51854ac73d988eff42c8066d7659baac7315a9f0a252db181134ce3aac9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Transactions now include a short random memo to improve uniqueness; visible in explorers, no user action required.
- Chores
  - Improved debug logging around transaction broadcast for better observability.
  - More informative error propagation when broadcasts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->