### PR TITLE
fix: enhancle sequence restore

### DIFF
--- a/node/broadcaster/tx.go
+++ b/node/broadcaster/tx.go
@@ -43,7 +43,7 @@ func (b *Broadcaster) handleMsgError(ctx types.Context, err error, broadcasterAc
 	expected, got, seqErr := btypes.ParseAccountSequenceMismatch(err.Error())
 	if seqErr == nil {
 		sentry_integration.CaptureCurrentHubException(err, sentry.LevelWarning)
-		if expected > b.peekLastSequenceInLocalPendingTx() {
+		if expected > got || expected > b.peekLastSequenceInLocalPendingTx(broadcasterAccount.addressString) {
 			broadcasterAccount.UpdateSequence(expected)
 		}
 		return errors.Wrapf(ErrAccountSequenceMismatch, "expected %d, got %d", expected, got)
@@ -180,7 +180,7 @@ func (b *Broadcaster) dequeueLocalPendingTx() {
 	b.pendingTxs = b.pendingTxs[1:]
 }
 
-func (b *Broadcaster) peekLastSequenceInLocalPendingTx() uint64 {
+func (b *Broadcaster) peekLastSequenceInLocalPendingTx(addr string) uint64 {
 	b.pendingTxMu.Lock()
 	defer b.pendingTxMu.Unlock()
 
@@ -188,7 +188,14 @@ func (b *Broadcaster) peekLastSequenceInLocalPendingTx() uint64 {
 		return 0
 	}
 
-	return b.pendingTxs[len(b.pendingTxs)-1].Sequence
+	// reverse iterate to find the last sequence of the given address
+	for i := len(b.pendingTxs) - 1; i >= 0; i-- {
+		if b.pendingTxs[i].Sender == addr {
+			return b.pendingTxs[i].Sequence
+		}
+	}
+
+	return 0
 }
 
 func (b *Broadcaster) RemovePendingTxsUntil(ctx types.Context, until uint64) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account sequence handling for queued/pending transactions: the broadcaster now more reliably detects and corrects sequence mismatches by considering recent local pending activity, reducing failed or out-of-order transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->