### PR TITLE
fix(executor): flush batch writer on ctx done to prevent corruption

### DIFF
--- a/cmd/opinitd/key.go
+++ b/cmd/opinitd/key.go
@@ -45,6 +45,8 @@ const (
 	flagOutput         = "output"
 	flagKeyType        = "key-type"
 	flagCoinType       = "coin-type"
+
+	outputFormatJSON = "json"
 )
 
 type keyJsonOutput map[string]keyJsonOutputElem
@@ -174,7 +176,7 @@ $ keys add l2 key2 --output json`),
 			outputFormat, _ := cmd.Flags().GetString(flagOutput)
 			var output string
 			switch outputFormat {
-			case "json": //nolint
+			case outputFormatJSON:
 				jsonOutput := make(keyJsonOutput)
 				jsonOutput[account.Name] = keyJsonOutputElem{
 					Address:  addrString,

--- a/cmd/opinitd/root.go
+++ b/cmd/opinitd/root.go
@@ -76,8 +76,8 @@ func getLogger(logLevel string, logFormat string) (*zap.Logger, error) {
 	}
 
 	encoding := "console"
-	if logFormat == "json" {
-		encoding = "json"
+	if logFormat == outputFormatJSON {
+		encoding = outputFormatJSON
 	}
 
 	config := zap.NewProductionConfig()

--- a/executor/batchsubmitter/batch.go
+++ b/executor/batchsubmitter/batch.go
@@ -64,7 +64,9 @@ func (bs *BatchSubmitter) prepareBatch(ctx types.Context, blockHeight int64) err
 		}
 
 		if bs.batchWriter != nil {
+			bs.batchWriterMu.Lock()
 			err := bs.batchWriter.Close()
+			bs.batchWriterMu.Unlock()
 			if err != nil {
 				return errors.Wrap(err, "failed to close batch writer")
 			}
@@ -101,7 +103,9 @@ func (bs *BatchSubmitter) prepareBatch(ctx types.Context, blockHeight int64) err
 		bs.localBatchInfo.Start = blockHeight
 		bs.localBatchInfo.End = 0
 		bs.localBatchInfo.BatchSize = 0
+		bs.batchWriterMu.Lock()
 		bs.batchWriter.Reset(bs.batchFile)
+		bs.batchWriterMu.Unlock()
 	}
 	return nil
 }
@@ -111,6 +115,10 @@ func (bs *BatchSubmitter) handleBatch(blockBytes []byte) (int, error) {
 	if len(blockBytes) == 0 {
 		return 0, errors.New("block bytes is empty")
 	}
+
+	bs.batchWriterMu.Lock()
+	defer bs.batchWriterMu.Unlock()
+
 	return bs.batchWriter.Write(prependLength(blockBytes))
 }
 
@@ -127,11 +135,14 @@ func (bs *BatchSubmitter) finalizeBatch(parentCtx types.Context, blockHeight int
 	if err != nil {
 		return errors.Wrap(err, "failed to query raw commit")
 	}
+	bs.batchWriterMu.Lock()
 	_, err = bs.batchWriter.Write(prependLength(rawCommit))
 	if err != nil {
+		bs.batchWriterMu.Unlock()
 		return errors.Wrap(err, "failed to write raw commit")
 	}
 	err = bs.batchWriter.Close()
+	bs.batchWriterMu.Unlock()
 	if err != nil {
 		return errors.Wrap(err, "failed to close batch writer")
 	}
@@ -236,7 +247,9 @@ func (bs *BatchSubmitter) batchFileSize(flush bool) (int64, error) {
 		return 0, errors.New("batch file is not initialized")
 	}
 	if flush {
+		bs.batchWriterMu.Lock()
 		err := bs.batchWriter.Flush()
+		bs.batchWriterMu.Unlock()
 		if err != nil {
 			return 0, errors.Wrap(err, "failed to flush batch writer")
 		}

--- a/executor/batchsubmitter/batch_submitter.go
+++ b/executor/batchsubmitter/batch_submitter.go
@@ -3,10 +3,12 @@ package batchsubmitter
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
 
+	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	ophosttypes "github.com/initia-labs/OPinit/x/ophost/types"
@@ -18,7 +20,6 @@ import (
 	nodetypes "github.com/initia-labs/opinit-bots/node/types"
 	childprovider "github.com/initia-labs/opinit-bots/provider/child"
 	"github.com/initia-labs/opinit-bots/types"
-	"github.com/pkg/errors"
 )
 
 type hostNode interface {
@@ -73,7 +74,7 @@ func NewBatchSubmitterV1(
 	cfg.ProcessType = nodetypes.PROCESS_TYPE_RAW
 	node, err := node.NewNode(cfg, db, appCodec, txConfig)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to create node"))
+		panic(pkgerrors.Wrap(err, "failed to create node"))
 	}
 
 	ch := &BatchSubmitter{
@@ -101,14 +102,14 @@ func NewBatchSubmitterV1(
 func (bs *BatchSubmitter) Initialize(ctx types.Context, syncedHeight int64, host hostNode, bridgeInfo ophosttypes.QueryBridgeResponse) error {
 	localBatchInfo, err := GetLocalBatchInfo(bs.DB())
 	if err != nil {
-		return errors.Wrap(err, "failed to get local batch info")
+		return pkgerrors.Wrap(err, "failed to get local batch info")
 	}
 	bs.localBatchInfo = &localBatchInfo
 
 	fileFlag := os.O_CREATE | os.O_RDWR | os.O_APPEND
 	bs.batchFile, err = os.OpenFile(ctx.HomePath()+"/batch", fileFlag, 0640)
 	if err != nil {
-		return errors.Wrap(err, "failed to open batch file")
+		return pkgerrors.Wrap(err, "failed to open batch file")
 	}
 
 	resetBatchFile := func(height int64) error {
@@ -118,7 +119,7 @@ func (bs *BatchSubmitter) Initialize(ctx types.Context, syncedHeight int64, host
 
 		err = SaveLocalBatchInfo(bs.DB(), *bs.localBatchInfo)
 		if err != nil {
-			return errors.Wrap(err, "failed to save local batch info")
+			return pkgerrors.Wrap(err, "failed to save local batch info")
 		}
 		// reset batch file
 		return bs.emptyBatchFile()
@@ -147,23 +148,23 @@ func (bs *BatchSubmitter) Initialize(ctx types.Context, syncedHeight int64, host
 	// linux command gzip use level 6 as default
 	bs.batchWriter, err = gzip.NewWriterLevel(bs.batchFile, 6)
 	if err != nil {
-		return errors.Wrap(err, "failed to create gzip writer")
+		return pkgerrors.Wrap(err, "failed to create gzip writer")
 	}
 
 	err = bs.node.Initialize(ctx, syncedHeight, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize node")
+		return pkgerrors.Wrap(err, "failed to initialize node")
 	}
 	bs.host = host
 	bs.bridgeInfo = bridgeInfo
 
 	res, err := bs.host.QueryBatchInfos(ctx, bridgeInfo.BridgeId)
 	if err != nil {
-		return errors.Wrap(err, "failed to query batch infos")
+		return pkgerrors.Wrap(err, "failed to query batch infos")
 	}
 	bs.batchInfos = res
 	if len(bs.batchInfos) == 0 {
-		return errors.New("no batch info")
+		return pkgerrors.New("no batch info")
 	}
 
 	for i, batchInfo := range bs.batchInfos {
@@ -188,16 +189,19 @@ func (bs *BatchSubmitter) Start(ctx types.Context) {
 	bs.node.Start(ctx)
 }
 
-func (bs *BatchSubmitter) Close() {
+func (bs *BatchSubmitter) Close(ctx types.Context) {
 	bs.closeOnce.Do(func() {
+		var errs []error
 		bs.batchWriterMu.Lock()
 		defer bs.batchWriterMu.Unlock()
 		if bs.batchWriter != nil {
-			bs.batchWriter.Close()
+			errs = append(errs, bs.batchWriter.Close())
 		}
 		if bs.batchFile != nil {
-			bs.batchFile.Close()
+			errs = append(errs, bs.batchFile.Close())
 		}
+
+		ctx.Logger().Error("failed to close batchSubmitter", zap.Error(errors.Join(errs...)))
 	})
 }
 
@@ -224,14 +228,14 @@ func (bs BatchSubmitter) DB() types.DB {
 func (bs *BatchSubmitter) checkBatchFileCorruption() (bool, error) {
 	info, err := bs.batchFile.Stat()
 	if err != nil {
-		return false, errors.Wrap(err, "failed to stat batch file")
+		return false, pkgerrors.Wrap(err, "failed to stat batch file")
 	}
 	if info.Size() == 0 {
 		return false, nil
 	}
 
 	if _, err := bs.batchFile.Seek(0, io.SeekStart); err != nil {
-		return false, errors.Wrap(err, "failed to seek batch file")
+		return false, pkgerrors.Wrap(err, "failed to seek batch file")
 	}
 
 	reader, err := gzip.NewReader(bs.batchFile)
@@ -246,7 +250,7 @@ func (bs *BatchSubmitter) checkBatchFileCorruption() (bool, error) {
 	}
 
 	if _, err := bs.batchFile.Seek(0, io.SeekEnd); err != nil {
-		return false, errors.Wrap(err, "failed to seek batch file")
+		return false, pkgerrors.Wrap(err, "failed to seek batch file")
 	}
 	return false, nil
 }

--- a/executor/batchsubmitter/batch_submitter.go
+++ b/executor/batchsubmitter/batch_submitter.go
@@ -41,6 +41,7 @@ type BatchSubmitter struct {
 
 	batchInfoMu    *sync.Mutex
 	batchInfos     []ophosttypes.BatchInfoWithOutput
+	batchWriterMu  sync.Mutex
 	batchWriter    *gzip.Writer
 	batchFile      *os.File
 	localBatchInfo *executortypes.LocalBatchInfo
@@ -50,6 +51,8 @@ type BatchSubmitter struct {
 	chainID string
 
 	stage types.CommitDB
+
+	closeOnce sync.Once
 
 	// status info
 	LastBatchEndBlockNumber int64
@@ -183,12 +186,16 @@ func (bs *BatchSubmitter) Start(ctx types.Context) {
 }
 
 func (bs *BatchSubmitter) Close() {
-	if bs.batchWriter != nil {
-		bs.batchWriter.Close()
-	}
-	if bs.batchFile != nil {
-		bs.batchFile.Close()
-	}
+	bs.closeOnce.Do(func() {
+		bs.batchWriterMu.Lock()
+		defer bs.batchWriterMu.Unlock()
+		if bs.batchWriter != nil {
+			bs.batchWriter.Close()
+		}
+		if bs.batchFile != nil {
+			bs.batchFile.Close()
+		}
+	})
 }
 
 func (bs *BatchSubmitter) SetBridgeInfo(bridgeInfo ophosttypes.QueryBridgeResponse) {

--- a/executor/batchsubmitter/batch_submitter.go
+++ b/executor/batchsubmitter/batch_submitter.go
@@ -41,7 +41,7 @@ type BatchSubmitter struct {
 
 	batchInfoMu    *sync.Mutex
 	batchInfos     []ophosttypes.BatchInfoWithOutput
-	batchWriterMu  sync.Mutex
+	batchWriterMu  *sync.Mutex
 	batchWriter    *gzip.Writer
 	batchFile      *os.File
 	localBatchInfo *executortypes.LocalBatchInfo
@@ -52,7 +52,7 @@ type BatchSubmitter struct {
 
 	stage types.CommitDB
 
-	closeOnce sync.Once
+	closeOnce *sync.Once
 
 	// status info
 	LastBatchEndBlockNumber int64
@@ -85,12 +85,15 @@ func NewBatchSubmitterV1(
 		batchCfg: batchCfg,
 
 		batchInfoMu:    &sync.Mutex{},
+		batchWriterMu:  &sync.Mutex{},
 		localBatchInfo: &executortypes.LocalBatchInfo{},
 
 		processedMsgs: make([]btypes.ProcessedMsgs, 0),
 		chainID:       chainID,
 
 		stage: db.NewStage(),
+
+		closeOnce: &sync.Once{},
 	}
 	return ch
 }

--- a/executor/batchsubmitter/batch_submitter.go
+++ b/executor/batchsubmitter/batch_submitter.go
@@ -201,7 +201,9 @@ func (bs *BatchSubmitter) Close(ctx types.Context) {
 			errs = append(errs, bs.batchFile.Close())
 		}
 
-		ctx.Logger().Error("failed to close batchSubmitter", zap.Error(errors.Join(errs...)))
+		if err := errors.Join(errs...); err != nil {
+			ctx.Logger().Error("failed to close batchSubmitter", zap.Error(err))
+		}
 	})
 }
 

--- a/executor/batchsubmitter/batch_test.go
+++ b/executor/batchsubmitter/batch_test.go
@@ -189,10 +189,12 @@ func TestPrepareBatch(t *testing.T) {
 			batchNode := node.NewTestNode(nodetypes.NodeConfig{}, batchDB, appCodec, txConfig, nil, nil)
 
 			batchSubmitter := BatchSubmitter{
-				node:        batchNode,
-				batchInfoMu: &sync.Mutex{},
-				batchInfos:  tc.batchInfoQueue,
-				da:          NewMockDA(nil, nil, 1, ""),
+				node:          batchNode,
+				batchInfoMu:   &sync.Mutex{},
+				batchWriterMu: &sync.Mutex{},
+				batchInfos:    tc.batchInfoQueue,
+				da:            NewMockDA(nil, nil, 1, ""),
+				closeOnce:     &sync.Once{},
 			}
 
 			err = SaveLocalBatchInfo(batchDB, tc.existingLocalBatchInfo)
@@ -241,7 +243,9 @@ func TestPrepareBatch(t *testing.T) {
 func TestHandleBatch(t *testing.T) {
 	var err error
 
-	batchSubmitter := BatchSubmitter{}
+	batchSubmitter := BatchSubmitter{
+		batchWriterMu: &sync.Mutex{},
+	}
 	batchSubmitter.batchFile, err = os.CreateTemp("", "batchfile")
 	require.NoError(t, err)
 	defer os.Remove(batchSubmitter.batchFile.Name())
@@ -286,9 +290,10 @@ func TestFinalizeBatch(t *testing.T) {
 	}
 
 	batchSubmitter := BatchSubmitter{
-		node:     batchNode,
-		da:       mockDA,
-		batchCfg: batchConfig,
+		node:          batchNode,
+		da:            mockDA,
+		batchCfg:      batchConfig,
+		batchWriterMu: &sync.Mutex{},
 		localBatchInfo: &executortypes.LocalBatchInfo{
 			Start: 1,
 			End:   10,

--- a/executor/batchsubmitter/handler_test.go
+++ b/executor/batchsubmitter/handler_test.go
@@ -69,7 +69,8 @@ func TestRawBlockHandler(t *testing.T) {
 				SubmissionInterval: 150,
 			},
 		},
-		batchInfoMu: &sync.Mutex{},
+		batchInfoMu:   &sync.Mutex{},
+		batchWriterMu: &sync.Mutex{},
 		batchInfos: []ophosttypes.BatchInfoWithOutput{
 			{
 				BatchInfo: ophosttypes.BatchInfo{

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -143,14 +143,14 @@ func (ex *Executor) Initialize(ctx types.Context) error {
 }
 
 func (ex *Executor) Start(ctx types.Context) error {
-	defer ex.Close()
+	defer ex.Close(ctx)
 
 	ctx.ErrGrp().Go(func() (err error) {
 		<-ctx.Done()
 
 		// close batch submitter eagerly on context cancellation to flush
 		// the gzip writer before the process is killed.
-		ex.batchSubmitter.Close()
+		ex.batchSubmitter.Close(ctx)
 
 		return ex.server.Shutdown()
 	})
@@ -180,8 +180,8 @@ func (ex *Executor) Start(ctx types.Context) error {
 	return ctx.ErrGrp().Wait()
 }
 
-func (ex *Executor) Close() {
-	ex.batchSubmitter.Close()
+func (ex *Executor) Close(ctx types.Context) {
+	ex.batchSubmitter.Close(ctx)
 }
 
 // makeDANode creates a DA node based on the bridge info

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -147,6 +147,11 @@ func (ex *Executor) Start(ctx types.Context) error {
 
 	ctx.ErrGrp().Go(func() (err error) {
 		<-ctx.Done()
+
+		// close batch submitter eagerly on context cancellation to flush
+		// the gzip writer before the process is killed.
+		ex.batchSubmitter.Close()
+
 		return ex.server.Shutdown()
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during shutdown and batch processing by synchronizing write/flush/close operations to prevent concurrent access and ensure data is flushed safely on exit.
* **Refactor**
  * Shutdown/cleanup now accepts a context to support coordinated, single-execution resource cleanup during termination.
* **Chores**
  * Standardized JSON output flag for command-line components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->