### PR TITLE
fix: do not validate oracle relay config if not enabled

### DIFF
--- a/executor/types/config_test.go
+++ b/executor/types/config_test.go
@@ -31,6 +31,10 @@ func TestConfigWithoutOracleRelayFails(t *testing.T) {
 	cfg.OracleRelay.Interval = 0
 
 	err := cfg.Validate()
+	require.NoError(t, err)
+
+	cfg.OracleRelay.Enable = true
+	err = cfg.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "oracle relay")
 }

--- a/executor/types/oracle.go
+++ b/executor/types/oracle.go
@@ -23,6 +23,9 @@ func DefaultOracleRelayConfig() OracleRelayConfig {
 
 // Validate validates the oracle relay configuration
 func (cfg OracleRelayConfig) Validate() error {
+	if !cfg.Enable {
+		return nil
+	}
 	if cfg.Interval <= 0 {
 		return errors.New("oracle relay interval must be greater than zero")
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oracle relay validation now skips interval checks when the relay is disabled, preventing spurious validation errors for disabled configurations.
* **Tests**
  * Updated validation tests to verify both disabled and enabled relay behaviors, ensuring an enabled relay still requires a positive interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->