### PR TITLE
fix: avoid adding MsgOracleRealyTypeUrl before config enabled

### DIFF
--- a/cmd/opinitd/tx.go
+++ b/cmd/opinitd/tx.go
@@ -97,15 +97,17 @@ func txGrantOracleCmd(baseCtx *cmdContext) *cobra.Command {
 				fmt.Println("MsgUpdateOracle authz grant already exists, skipping")
 			}
 
-			if !hasAuthzGrant(existingGrants, types.MsgRelayOracleTypeUrl) {
-				grantRelayMsg, err := authz.NewMsgGrant(account.GetAddress(), oracleAddress, authz.NewGenericAuthorization(types.MsgRelayOracleTypeUrl), nil)
-				if err != nil {
-					return err
+			if cfg.OracleRelay.Enable {
+				if !hasAuthzGrant(existingGrants, types.MsgRelayOracleTypeUrl) {
+					grantRelayMsg, err := authz.NewMsgGrant(account.GetAddress(), oracleAddress, authz.NewGenericAuthorization(types.MsgRelayOracleTypeUrl), nil)
+					if err != nil {
+						return err
+					}
+					msgs = append(msgs, grantRelayMsg)
+					fmt.Println("Adding authz grant for MsgRelayOracleData")
+				} else {
+					fmt.Println("MsgRelayOracleData authz grant already exists, skipping")
 				}
-				msgs = append(msgs, grantRelayMsg)
-				fmt.Println("Adding authz grant for MsgRelayOracleData")
-			} else {
-				fmt.Println("MsgRelayOracleData authz grant already exists, skipping")
 			}
 
 			existingAllowance, err := queryFeegrant(baseCtx, cfg, account.GetAddressString(), oracleAddress.String())
@@ -113,7 +115,10 @@ func txGrantOracleCmd(baseCtx *cmdContext) *cobra.Command {
 				return errors.Wrap(err, "failed to query feegrant")
 			}
 
-			requiredMsgTypes := []string{types.MsgRelayOracleTypeUrl, types.MsgUpdateOracleTypeUrl, types.MsgAuthzExecTypeUrl, types.MsgUpdateClientTypeUrl}
+			requiredMsgTypes := []string{types.MsgRelayOracleTypeUrl, types.MsgAuthzExecTypeUrl}
+			if cfg.OracleRelay.Enable {
+				requiredMsgTypes = append(requiredMsgTypes, types.MsgUpdateOracleTypeUrl, types.MsgUpdateClientTypeUrl)
+			}
 
 			if existingAllowance != nil {
 				hasAllTypes, err := hasAllMsgTypes(existingAllowance, requiredMsgTypes)

--- a/cmd/opinitd/tx.go
+++ b/cmd/opinitd/tx.go
@@ -115,9 +115,9 @@ func txGrantOracleCmd(baseCtx *cmdContext) *cobra.Command {
 				return errors.Wrap(err, "failed to query feegrant")
 			}
 
-			requiredMsgTypes := []string{types.MsgRelayOracleTypeUrl, types.MsgAuthzExecTypeUrl}
+			requiredMsgTypes := []string{types.MsgUpdateOracleTypeUrl, types.MsgAuthzExecTypeUrl}
 			if cfg.OracleRelay.Enable {
-				requiredMsgTypes = append(requiredMsgTypes, types.MsgUpdateOracleTypeUrl, types.MsgUpdateClientTypeUrl)
+				requiredMsgTypes = append(requiredMsgTypes, types.MsgRelayOracleTypeUrl, types.MsgUpdateClientTypeUrl)
 			}
 
 			if existingAllowance != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Oracle relay authorization is now governed by a configuration flag: when enabled, relay-related grants are validated and created as before; when disabled, relay grant processing is skipped.
  * Status messages and the set of required message types for authorization checks have been updated to reflect the enabled/disabled relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->